### PR TITLE
Allow open-service-broker to accept coma-separated ip ranges in its config

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/endpoint/EndpointLookup.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/endpoint/EndpointLookup.groovy
@@ -18,10 +18,11 @@ class EndpointLookup {
         parseProtocols(config).each { String protocol ->
             portsForServiceInstance.each {
                 String port ->
-                    result.add(new Endpoint(protocol: protocol, ports: port, destination: config.ipRange))
+                    parseIpRanges(config).each { String ipRange ->
+                        result.add(new Endpoint(protocol: protocol, ports: port, destination: ipRange.trim()))
+                    }
             }
         }
-
         return result
     }
 
@@ -29,6 +30,15 @@ class EndpointLookup {
         def result = config.protocols?.split(",")
         if (result == null || result.size() == 0) {
             return DEFAULT_PROTOCOLS
+        }
+        return Arrays.asList(result)
+    }
+
+    private Collection<String> parseIpRanges(EndpointConfig config) {
+        def result = config.ipRange?.split(",")
+        if (result == null || result.size() == 0) {
+            throw new RuntimeException("Invalid IpRange configuration. Ip ranges should be separated by a comma and" +
+                    " should either be a range or CIDR notation. See https://docs.cloudfoundry.org/adminguide/app-sec-groups.html")
         }
         return Arrays.asList(result)
     }


### PR DESCRIPTION
This change will allow the open-service-broker to parse the IP field and return multiple security groups for each range.