### PR TITLE
Update automation config to be compatible with MongoDB Ops Manager version 3.4

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BindingController.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BindingController.groovy
@@ -106,7 +106,7 @@ class BindingController extends BaseController {
 
         serviceBindingPersistenceService.delete(serviceBinding, serviceInstance)
         log.info("Servicebinding ${serviceBinding.guid} deleted")
-        return void
+        return new ResponseEntity<String>('{}', HttpStatus.OK)
     }
 
     private ServiceBinding checkServiceBinding(String bindingGuid) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseConfig.groovy
@@ -21,6 +21,7 @@ class MongoDbEnterpriseConfig implements BoshBasedServiceConfig {
     String logFolder
     int authSchemaVersion
     String mongoDbVersion
+    String featureCompatibilityVersion
     boolean configureDefaultBackupOptions
     int snapshotIntervalHours
     int snapshotRetentionDays
@@ -59,6 +60,7 @@ class MongoDbEnterpriseConfig implements BoshBasedServiceConfig {
                 ", logFolder='" + logFolder + '\'' +
                 ", authSchemaVersion=" + authSchemaVersion +
                 ", mongoDbVersion='" + mongoDbVersion + '\'' +
+                ", featureCompatibilityVersion='" + featureCompatibilityVersion + '\'' +
                 ", configureDefaultBackupOptions=" + configureDefaultBackupOptions +
                 ", snapshotIntervalHours=" + snapshotIntervalHours +
                 ", snapshotRetentionDays=" + snapshotRetentionDays +

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/automation/AuthenticationDto.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/automation/AuthenticationDto.groovy
@@ -10,6 +10,7 @@ class AuthenticationDto implements Serializable {
     String autoPwd
     String autoAuthMechanism
     String keyfile
+    String keyfileWindows
     String key
     List<DbUser> usersWanted
     List<DbUser2Delete> usersDeleted

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/automation/ProcessDto.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/automation/ProcessDto.groovy
@@ -8,5 +8,6 @@ class ProcessDto implements Serializable {
     String cluster
     LogRotateDto logRotate
     int authSchemaVersion
+    String featureCompatibilityVersion
     ProcessArgumentsV26Dto args2_6
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -234,6 +234,7 @@ class OpsManagerFacade {
                 processType: PROCESS_TYPE_MONGOD,
                 name: name,
                 authSchemaVersion: mongoDbEnterpriseConfig.authSchemaVersion,
+                featureCompatibilityVersion: mongoDbEnterpriseConfig.featureCompatibilityVersion,
                 hostname: hostPort.host,
                 logRotate: createLogRotateDto(),
                 args2_6: new ProcessArgumentsV26Dto(net: new ProcessArgumentsV26Dto.Net(port: hostPort.port),

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -387,6 +387,7 @@ class OpsManagerFacade {
             AutomationConfigDto automationConfigDto ->
                 automationConfigDto.processes = []
                 automationConfigDto.replicaSets = []
+                setAuthMechamnismIfNotAlreadySet(automationConfigDto.auth)
         })
     }
 

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -39,6 +39,7 @@ com.swisscom.cloud.sb.broker:
       logFolder: '/var/vcap/sys/log/mms-automation-agent'
       authSchemaVersion: 5
       mongoDbVersion: '3.2.6-ent'
+      featureCompatibilityVersion: '3.4'
       configureDefaultBackupOptions: true
       snapshotIntervalHours: 6 #Supported values are 6, 8, 12, and 24
       snapshotRetentionDays: 3 # Supported values are 1 - 5

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/OpsManagerFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/OpsManagerFacadeSpec.groovy
@@ -250,7 +250,7 @@ class OpsManagerFacadeSpec extends Specification {
 
     def "automation update functions correctly when current and to-be-updated configurations are same "() {
         given:
-        opsManagerClient.getAutomationConfig(groupId) >> new AutomationConfigDto(processes: [], replicaSets: [])
+        opsManagerClient.getAutomationConfig(groupId) >> new AutomationConfigDto(processes: [], replicaSets: [], auth: new AuthenticationDto(autoAuthMechanism: "MONGODB-CR"))
 
         when:
         opsManagerFacade.undeploy(groupId)
@@ -261,7 +261,7 @@ class OpsManagerFacadeSpec extends Specification {
 
     def "automation update functions correctly when current and to-be-updated configurations are different"() {
         given:
-        opsManagerClient.getAutomationConfig(groupId) >> new AutomationConfigDto(processes: [new ProcessDto()], replicaSets: [])
+        opsManagerClient.getAutomationConfig(groupId) >> new AutomationConfigDto(processes: [new ProcessDto()], replicaSets: [], auth: new AuthenticationDto(autoAuthMechanism: "MONGODB-CR"))
 
         when:
         opsManagerFacade.undeploy(groupId)


### PR DESCRIPTION
This updates the automation config to be compatible with Ops Manager version 3.4.
Changes:
- New fields added: proceses.featureCompatibilityVersion, auth.keyfileWindows
- ensures required field AuthMechamnism is present when removing processes / replicasets from a group
- fixes bug which returned 'void' instead of a valid http response on unbind requests.