### PR TITLE
refactor ip range and protocols to allow for multiple ranges/protocols

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/endpoint/EndpointConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/endpoint/EndpointConfig.groovy
@@ -3,6 +3,6 @@ package com.swisscom.cloud.sb.broker.cfextensions.endpoint
 import com.swisscom.cloud.sb.broker.config.Config
 
 trait EndpointConfig implements Config {
-    String ipRange
-    String protocols
+    List<String> ipRanges
+    List<String> protocols
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/endpoint/EndpointLookup.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/endpoint/EndpointLookup.groovy
@@ -15,21 +15,17 @@ class EndpointLookup {
     Collection<Endpoint> findEndpoints(ServiceInstance serviceInstance, EndpointConfig config) {
         def result = new LinkedList<Endpoint>()
         def portsForServiceInstance = ServiceDetailsHelper.from(serviceInstance).findAllWithServiceDetailType(ServiceDetailType.PORT)
-        parseProtocols(config).each { String protocol ->
-            portsForServiceInstance.each {
-                String port ->
-                    result.add(new Endpoint(protocol: protocol, ports: port, destination: config.ipRange))
+        if (config.protocols.size() == 0){
+            config.protocols.addAll(DEFAULT_PROTOCOLS)
+        }
+
+        config.protocols.each { String protocol ->
+            config.ipRanges.each { String ipRange ->
+                portsForServiceInstance.each { String port ->
+                        result.add(new Endpoint(protocol: protocol, ports: port, destination: ipRange))
+                }
             }
         }
-
         return result
-    }
-
-    private Collection<String> parseProtocols(EndpointConfig config) {
-        def result = config.protocols?.split(",")
-        if (result == null || result.size() == 0) {
-            return DEFAULT_PROTOCOLS
-        }
-        return Arrays.asList(result)
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseConfig.groovy
@@ -46,7 +46,7 @@ class MongoDbEnterpriseConfig implements BoshBasedServiceConfig {
                 ", com_swisscom_cloud_sb_broker_services_bosh_BoshBasedServiceConfig__boshManifestFolder='" + com_swisscom_cloud_sb_broker_services_bosh_BoshBasedServiceConfig__boshManifestFolder + '\'' +
                 ", com_swisscom_cloud_sb_broker_services_bosh_BoshConfig__boshDirectorBaseUrl='" + com_swisscom_cloud_sb_broker_services_bosh_BoshConfig__boshDirectorBaseUrl + '\'' +
                 ", com_swisscom_cloud_sb_broker_services_bosh_BoshConfig__boshDirectorUsername='" + com_swisscom_cloud_sb_broker_services_bosh_BoshConfig__boshDirectorUsername + '\'' +
-                ", com_swisscom_cloud_sb_broker_services_common_endpoint_EndpointConfig__ipRange='" + com_swisscom_cloud_sb_broker_cfextensions_endpoint_EndpointConfig__ipRange + '\'' +
+                ", com_swisscom_cloud_sb_broker_services_common_endpoint_EndpointConfig__ipRanges='" + com_swisscom_cloud_sb_broker_cfextensions_endpoint_EndpointConfig__ipRanges + '\'' +
                 ", com_swisscom_cloud_sb_broker_services_common_endpoint_EndpointConfig__protocols='" + com_swisscom_cloud_sb_broker_cfextensions_endpoint_EndpointConfig__protocols + '\'' +
                 ", opsManagerUrl='" + opsManagerUrl + '\'' +
                 ", opsManagerUrlForAutomationAgent='" + opsManagerUrlForAutomationAgent + '\'' +

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -49,8 +49,8 @@ com.swisscom.cloud.sb.broker:
       retryIntervalInSeconds: 15
       maxRetryDurationInMinutes: 30
       advancedBinding: true
-      ipRange: '172.16.255.224/27'
-      protocols: 'tcp' # 'tcp,udp,icmp'
+      ipRanges: ['172.16.255.224/27']
+      protocols: ['tcp'] # 'tcp,udp,icmp'
       boshDirectorBaseUrl: 'https://localhost:25556'
       boshDirectorUsername:
       boshDirectorPassword:


### PR DESCRIPTION
result of discussion on https://github.com/swisscom/open-service-broker/pull/4
now using native yaml features instead of parsing ip ranges and protocols in the code.
