### PR TITLE
add check whether kubernetes service deployment is successful

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/KubernetesRedisFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/KubernetesRedisFunctionalSpec.groovy
@@ -11,7 +11,6 @@ import static com.swisscom.cloud.sb.broker.services.common.ServiceProviderLookup
 @IgnoreIf({ !Boolean.valueOf(System.properties['com.swisscom.cloud.sb.broker.run3rdPartyDependentTests']) })
 class KubernetesRedisFunctionalSpec extends BaseFunctionalSpec {
 
-
     @Autowired
     private ApplicationContext appContext
     @Autowired
@@ -19,13 +18,12 @@ class KubernetesRedisFunctionalSpec extends BaseFunctionalSpec {
 
     def setup() {
         serviceLifeCycler.createServiceIfDoesNotExist('redis-kubernetes', findInternalName(KubernetesRedisServiceProvider))
-
     }
 
     def "Create and remove a redis instance"() {
         when:
         try {
-            serviceLifeCycler.createServiceInstanceAndServiceBindingAndAssert(40, true, true)
+            serviceLifeCycler.createServiceInstanceAndServiceBindingAndAssert(300, true, true)
         }
         finally {
             serviceLifeCycler.deleteServiceBindingAndAssert()
@@ -37,4 +35,3 @@ class KubernetesRedisFunctionalSpec extends BaseFunctionalSpec {
     }
 
 }
-

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/config/AbstractKubernetesServiceConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/config/AbstractKubernetesServiceConfig.groovy
@@ -1,0 +1,7 @@
+package com.swisscom.cloud.sb.broker.services.kubernetes.config
+
+import com.swisscom.cloud.sb.broker.config.Config
+
+trait AbstractKubernetesServiceConfig implements Config {
+    boolean enablePodLabelHealthzFilter
+}

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
@@ -1,0 +1,68 @@
+package com.swisscom.cloud.sb.broker.services.kubernetes.facade
+
+import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
+import com.swisscom.cloud.sb.broker.services.kubernetes.config.AbstractKubernetesServiceConfig
+import com.swisscom.cloud.sb.broker.services.kubernetes.config.KubernetesConfig
+import com.swisscom.cloud.sb.broker.services.kubernetes.endpoint.EndpointMapper
+import groovy.json.JsonSlurper
+import groovy.transform.TypeChecked
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.HttpMethod
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.HttpStatusCodeException
+
+import static groovy.transform.TypeCheckingMode.SKIP
+
+abstract class AbstractKubernetesFacade implements KubernetesFacade {
+    @Autowired
+    protected KubernetesClient<?> kubernetesClient
+    @Autowired
+    protected KubernetesConfig kubernetesConfig
+    @Autowired
+    protected AbstractKubernetesServiceConfig kubernetesServiceConfig
+
+    @Override
+    boolean isKubernetesDeploymentSuccessful(String serviceInstanceGuid) {
+        try {
+            def pods = getPodList(serviceInstanceGuid)
+            def consideredPods = getPodsConsideredForReadiness(pods)
+            return checkPodsReadinessState(consideredPods)
+        } catch (HttpStatusCodeException e) {
+            log.error("Readiness check for kubernetes service with instance guid " + serviceInstanceGuid
+                    + " failed, got HTTP status code: " + e.getStatusCode().toString())
+            return false
+        }
+    }
+
+    @TypeChecked(SKIP)
+    private List getPodList(String serviceInstanceGuid) throws HttpStatusCodeException {
+        ResponseEntity<String> podListResponse = kubernetesClient.exchange(
+                EndpointMapper.INSTANCE.getEndpointUrlByType("Namespace").getFirst() + '/' + serviceInstanceGuid + '/pods',
+                HttpMethod.GET, "", String.class)
+        def jsonSlurper = new JsonSlurper()
+        def podList = jsonSlurper.parseText(podListResponse.body)
+        assert podList.kind == 'PodList'
+        return podList.items
+    }
+
+    /**
+     * healthz is an internally defined label in our kubernetes service deployments.
+     */
+    @TypeChecked(SKIP)
+    private List getPodsConsideredForReadiness(List pods) {
+        if (kubernetesServiceConfig.enablePodLabelHealthzFilter) {
+            return pods.findAll { it.metadata.labels.healthz == "true" }
+        } else {
+            return pods
+        }
+    }
+
+    @TypeChecked(SKIP)
+    private boolean checkPodsReadinessState(List pods) {
+        def podsConditions = pods.collect { it.status.conditions }.flatten()
+        def hasConditionsReadyAndStatusFalse = podsConditions.findAll { it.type == 'Ready' }.findAll {
+            it.status == 'False'
+        }
+        return (hasConditionsReadyAndStatusFalse.size() == 0 && !pods.empty)
+    }
+}

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
@@ -14,12 +14,16 @@ import org.springframework.web.client.HttpStatusCodeException
 import static groovy.transform.TypeCheckingMode.SKIP
 
 abstract class AbstractKubernetesFacade implements KubernetesFacade {
+    protected final KubernetesClient<?> kubernetesClient
+    protected final KubernetesConfig kubernetesConfig
+    protected final AbstractKubernetesServiceConfig kubernetesServiceConfig
+
     @Autowired
-    protected KubernetesClient<?> kubernetesClient
-    @Autowired
-    protected KubernetesConfig kubernetesConfig
-    @Autowired
-    protected AbstractKubernetesServiceConfig kubernetesServiceConfig
+    AbstractKubernetesFacade(KubernetesClient kubernetesClient, KubernetesConfig kubernetesConfig, AbstractKubernetesServiceConfig abstractKubernetesServiceConfig) {
+        this.kubernetesClient = kubernetesClient
+        this.kubernetesConfig = kubernetesConfig
+        this.kubernetesServiceConfig = abstractKubernetesServiceConfig
+    }
 
     @Override
     boolean isKubernetesDeploymentSuccessful(String serviceInstanceGuid) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/KubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/KubernetesFacade.groovy
@@ -3,21 +3,7 @@ package com.swisscom.cloud.sb.broker.services.kubernetes.facade
 import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
 import com.swisscom.cloud.sb.broker.model.ProvisionRequest
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
-import com.swisscom.cloud.sb.broker.provisioning.DeprovisionResponse
-import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
-import com.swisscom.cloud.sb.broker.services.kubernetes.endpoint.parameters.EndpointMapperParamsDecorated
-import com.swisscom.cloud.sb.broker.services.kubernetes.endpoint.parameters.KubernetesRedisConfigUrlParams
-import com.swisscom.cloud.sb.broker.services.kubernetes.facade.redis.config.KubernetesRedisConfig
-import com.swisscom.cloud.sb.broker.services.kubernetes.templates.KubernetesTemplate
-import com.swisscom.cloud.sb.broker.services.kubernetes.templates.KubernetesTemplateManager
-import com.swisscom.cloud.sb.broker.services.kubernetes.templates.decorator.KubernetesTemplateVariablesDecorator
-import com.swisscom.cloud.sb.broker.util.ServiceDetailKey
 import groovy.transform.CompileStatic
-import groovy.util.logging.Log4j
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.data.util.Pair
-import org.springframework.http.HttpMethod
-import org.springframework.stereotype.Component
 
 @CompileStatic
 interface KubernetesFacade {
@@ -25,5 +11,7 @@ interface KubernetesFacade {
     Collection<ServiceDetail> provision(ProvisionRequest context)
 
     void deprovision(DeprovisionRequest request)
+
+    boolean isKubernetesDeploymentSuccessful(String serviceInstanceGuid)
 
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
@@ -3,13 +3,12 @@ package com.swisscom.cloud.sb.broker.services.kubernetes.facade.redis
 import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
 import com.swisscom.cloud.sb.broker.model.ProvisionRequest
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
-import com.swisscom.cloud.sb.broker.provisioning.DeprovisionResponse
 import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
 import com.swisscom.cloud.sb.broker.services.kubernetes.dto.ServiceResponse
 import com.swisscom.cloud.sb.broker.services.kubernetes.endpoint.EndpointMapper
 import com.swisscom.cloud.sb.broker.services.kubernetes.endpoint.parameters.EndpointMapperParamsDecorated
 import com.swisscom.cloud.sb.broker.services.kubernetes.endpoint.parameters.KubernetesRedisConfigUrlParams
-import com.swisscom.cloud.sb.broker.services.kubernetes.facade.KubernetesFacade
+import com.swisscom.cloud.sb.broker.services.kubernetes.facade.AbstractKubernetesFacade
 import com.swisscom.cloud.sb.broker.services.kubernetes.facade.redis.config.KubernetesRedisConfig
 import com.swisscom.cloud.sb.broker.services.kubernetes.templates.KubernetesTemplate
 import com.swisscom.cloud.sb.broker.services.kubernetes.templates.KubernetesTemplateManager
@@ -18,7 +17,7 @@ import com.swisscom.cloud.sb.broker.services.kubernetes.templates.decorator.Kube
 import com.swisscom.cloud.sb.broker.services.kubernetes.templates.generators.KubernetesTemplatePasswordGenerator
 import com.swisscom.cloud.sb.broker.util.ServiceDetailKey
 import groovy.transform.CompileStatic
-import groovy.util.logging.Log4j
+import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.util.Pair
 import org.springframework.http.HttpMethod
@@ -26,9 +25,9 @@ import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
 
 @Component
-@Log4j
+@Slf4j
 @CompileStatic
-class KubernetesFacadeRedis implements KubernetesFacade {
+class KubernetesFacadeRedis extends AbstractKubernetesFacade {
 
     private final KubernetesClient<?> kubernetesClient
     private final KubernetesTemplateManager kubernetesTemplateManager
@@ -82,6 +81,5 @@ class KubernetesFacadeRedis implements KubernetesFacade {
             }
         }
     }
-
 
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/config/KubernetesRedisConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/config/KubernetesRedisConfig.groovy
@@ -2,6 +2,7 @@ package com.swisscom.cloud.sb.broker.services.kubernetes.facade.redis.config
 
 import com.swisscom.cloud.sb.broker.cfextensions.endpoint.EndpointConfig
 import com.swisscom.cloud.sb.broker.config.Config
+import com.swisscom.cloud.sb.broker.services.kubernetes.config.AbstractKubernetesServiceConfig
 import groovy.transform.AutoClone
 import groovy.transform.CompileStatic
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -11,7 +12,7 @@ import org.springframework.context.annotation.Configuration
 @CompileStatic
 @Configuration
 @ConfigurationProperties(prefix = 'com.swisscom.cloud.sb.broker.service.kubernetes.redis.v1')
-class KubernetesRedisConfig implements Config, EndpointConfig {
+class KubernetesRedisConfig implements Config, EndpointConfig, AbstractKubernetesServiceConfig {
     String kubernetesRedisHost
     String kubernetesRedisV1TemplatesPath
     HashMap<String, String> redisConfigurationDefaults

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/service/KubernetesRedisServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/service/KubernetesRedisServiceProvider.groovy
@@ -63,8 +63,9 @@ class KubernetesRedisServiceProvider extends AsyncServiceProvider<KubernetesConf
 
     @VisibleForTesting
     private StateMachine createProvisionStateMachine() {
-        StateMachine stateMachine = new StateMachine([KubernetesServiceProvisionState.KUBERNETES_SERVICE_PROVISION])
-        stateMachine.addAll([KubernetesServiceProvisionState.KUBERNETES_SERVICE_PROVISION_SUCCESS])
+        StateMachine stateMachine = new StateMachine([KubernetesServiceProvisionState.KUBERNETES_SERVICE_PROVISION,
+                                                      KubernetesServiceProvisionState.CHECK_SERVICE_DEPLOYMENT_SUCCESSFUL,
+                                                      KubernetesServiceProvisionState.KUBERNETES_SERVICE_PROVISION_SUCCESS])
         return stateMachine
     }
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/service/state/KubernetesServiceProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/service/state/KubernetesServiceProvisionState.groovy
@@ -14,7 +14,18 @@ enum KubernetesServiceProvisionState implements ServiceStateWithAction<Kubernete
     () {
         @Override
         StateChangeActionResult triggerAction(KubernetesServiceStateMachineContext stateContext) {
-            return new StateChangeActionResult(go2NextState: true, details: stateContext.kubernetesFacade.provision(stateContext.lastOperationJobContext.provisionRequest))
+            return new StateChangeActionResult(
+                    go2NextState: true,
+                    details: stateContext.kubernetesFacade.provision(stateContext.lastOperationJobContext.provisionRequest))
+        }
+    }),
+
+    CHECK_SERVICE_DEPLOYMENT_SUCCESSFUL(LastOperation.Status.IN_PROGRESS, new OnStateChange<KubernetesServiceStateMachineContext>
+    () {
+        @Override
+        StateChangeActionResult triggerAction(KubernetesServiceStateMachineContext stateContext) {
+            return new StateChangeActionResult(
+                    go2NextState: stateContext.kubernetesFacade.isKubernetesDeploymentSuccessful(stateContext.lastOperationJobContext.provisionRequest.serviceInstanceGuid))
         }
     }),
 

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacadeSpec.groovy
@@ -1,0 +1,74 @@
+package com.swisscom.cloud.sb.broker.services.kubernetes.facade
+
+import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
+import com.swisscom.cloud.sb.broker.model.ProvisionRequest
+import com.swisscom.cloud.sb.broker.model.ServiceDetail
+import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
+import com.swisscom.cloud.sb.broker.services.kubernetes.config.AbstractKubernetesServiceConfig
+import com.swisscom.cloud.sb.broker.services.kubernetes.config.KubernetesConfig
+import com.swisscom.cloud.sb.broker.services.kubernetes.templates.KubernetesTemplateManager
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import spock.lang.Specification
+
+class AbstractKubernetesFacadeSpec extends Specification {
+    AbstractKubernetesFacade kubernetesFacade
+    AbstractKubernetesServiceConfig kubernetesServiceConfig
+    KubernetesClient kubernetesClient
+    KubernetesTemplateManager kubernetesTemplateManager
+    KubernetesConfig kubernetesConfig
+
+    def setup() {
+        kubernetesClient = Mock()
+        kubernetesConfig = Stub()
+        kubernetesServiceConfig = Mock()
+        kubernetesServiceConfig.enablePodLabelHealthzFilter >> true
+        kubernetesTemplateManager = Mock()
+        and:
+        kubernetesFacade = new AbstractKubernetesFacade() {
+            @Override
+            Collection<ServiceDetail> provision(ProvisionRequest context) {
+                return null
+            }
+
+            @Override
+            void deprovision(DeprovisionRequest request) {
+
+            }
+        }
+        kubernetesFacade.kubernetesClient = kubernetesClient
+        kubernetesFacade.kubernetesConfig = kubernetesConfig
+        kubernetesFacade.kubernetesServiceConfig = kubernetesServiceConfig
+    }
+
+
+    def "return correct provision status when service ready"() {
+        when:
+        String serviceInstance = 'test'
+        kubernetesClient.exchange(_, _, _, _) >> new ResponseEntity(mockReadyPodListResponse(), HttpStatus.OK)
+        and:
+        boolean deployTaskSuccessful = kubernetesFacade.isKubernetesDeploymentSuccessful(serviceInstance)
+        then:
+        deployTaskSuccessful == true
+    }
+
+    def "return correct provision status when service not ready"() {
+        when:
+        String serviceInstance = 'test'
+        kubernetesClient.exchange(_, _, _, _) >> new ResponseEntity(mockNotReadyPodListResponse(), HttpStatus.OK)
+        and:
+        boolean deployTaskSuccessful = kubernetesFacade.isKubernetesDeploymentSuccessful(serviceInstance)
+        then:
+        deployTaskSuccessful == false
+    }
+
+
+    private String mockReadyPodListResponse() {
+        return new File('src/test/resources/kubernetes/kubernetes-podlist-response-ready.json').text
+    }
+
+    private String mockNotReadyPodListResponse() {
+        return new File('src/test/resources/kubernetes/kubernetes-podlist-response-notready.json').text
+    }
+
+}

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacadeSpec.groovy
@@ -25,7 +25,7 @@ class AbstractKubernetesFacadeSpec extends Specification {
         kubernetesServiceConfig.enablePodLabelHealthzFilter >> true
         kubernetesTemplateManager = Mock()
         and:
-        kubernetesFacade = new AbstractKubernetesFacade() {
+        kubernetesFacade = new AbstractKubernetesFacade(kubernetesClient, kubernetesConfig, kubernetesServiceConfig) {
             @Override
             Collection<ServiceDetail> provision(ProvisionRequest context) {
                 return null
@@ -36,9 +36,6 @@ class AbstractKubernetesFacadeSpec extends Specification {
 
             }
         }
-        kubernetesFacade.kubernetesClient = kubernetesClient
-        kubernetesFacade.kubernetesConfig = kubernetesConfig
-        kubernetesFacade.kubernetesServiceConfig = kubernetesServiceConfig
     }
 
 

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedisSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedisSpec.groovy
@@ -182,4 +182,5 @@ class KubernetesFacadeRedisSpec extends Specification {
         }
     }
 
+
 }

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedisSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedisSpec.groovy
@@ -6,6 +6,7 @@ import com.swisscom.cloud.sb.broker.model.Plan
 import com.swisscom.cloud.sb.broker.model.ProvisionRequest
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
+import com.swisscom.cloud.sb.broker.services.kubernetes.config.KubernetesConfig
 import com.swisscom.cloud.sb.broker.services.kubernetes.dto.Port
 import com.swisscom.cloud.sb.broker.services.kubernetes.dto.Selector
 import com.swisscom.cloud.sb.broker.services.kubernetes.dto.ServiceResponse
@@ -37,15 +38,17 @@ class KubernetesFacadeRedisSpec extends Specification {
     KubernetesTemplateManager kubernetesTemplateManager
     ProvisionRequest provisionRequest
     DeprovisionRequest deprovisionRequest
-    KubernetesRedisConfig kubernetesConfig
+    KubernetesConfig kubernetesConfig
+    KubernetesRedisConfig kubernetesRedisConfig
     EndpointMapperParamsDecorated endpointMapperParamsDecorated
 
     def setup() {
         kubernetesClient = Mock()
         kubernetesConfig = Stub()
+        kubernetesRedisConfig = Stub()
         deprovisionRequest = Stub()
         endpointMapperParamsDecorated = Mock()
-        kubernetesConfig.kubernetesRedisHost >> "host.redis"
+        kubernetesRedisConfig.kubernetesRedisHost >> "host.redis"
         KubernetesTemplate kubernetesTemplate = new KubernetesTemplate(TEMPLATE_EXAMPLE)
         endpointMapperParamsDecorated.getEndpointUrlByTypeWithParams(_, _) >> new Pair("/endpoint/", new NamespaceResponse())
         kubernetesTemplateManager = Mock()
@@ -57,7 +60,7 @@ class KubernetesFacadeRedisSpec extends Specification {
         }
         mockProvisionRequest()
         and:
-        kubernetesRedisClientRedisDecorated = new KubernetesFacadeRedis(kubernetesConfig, kubernetesClient, kubernetesTemplateManager, endpointMapperParamsDecorated)
+        kubernetesRedisClientRedisDecorated = new KubernetesFacadeRedis(kubernetesClient, kubernetesConfig, kubernetesRedisConfig, kubernetesTemplateManager, endpointMapperParamsDecorated)
     }
 
 

--- a/broker/src/test/resources/kubernetes/kubernetes-podlist-response-notready.json
+++ b/broker/src/test/resources/kubernetes/kubernetes-podlist-response-notready.json
@@ -1,0 +1,73 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "items": [
+    {
+      "metadata": {
+        "uid": "3637283f-7c08-11e7-8b9a-fa163e3727e9",
+        "labels": {
+          "healthz": "true",
+          "instances": "operator"
+        }
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [operator]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "uid": "36292b9a-7c08-11e7-8b9a-fa163e3727e9",
+        "labels": {
+          "instances": "redis"
+        }
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          },
+          {
+            "type": "Ready",
+            "status": "False",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [operator]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/broker/src/test/resources/kubernetes/kubernetes-podlist-response-ready.json
+++ b/broker/src/test/resources/kubernetes/kubernetes-podlist-response-ready.json
@@ -1,0 +1,73 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "items": [
+    {
+      "metadata": {
+        "uid": "3637283f-7c08-11e7-8b9a-fa163e3727e9",
+        "labels": {
+          "healthz": "true",
+          "instances": "operator"
+        }
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [operator]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          }
+        ]
+      }
+    },
+    {
+      "metadata": {
+        "uid": "36292b9a-7c08-11e7-8b9a-fa163e3727e9",
+        "labels": {
+          "instances": "redis"
+        }
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z",
+            "reason": "ContainersNotReady",
+            "message": "containers with unready status: [operator]"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-08-17T12:15:29Z"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Motivation**
After requesting service deployment to kubernetes and getting an ACCEPTED response, OSB should check if the deployment is actually successful before responding with the provision state SUCCESS.

**Description**
This checks pods with our custom label healthz set to true or optionally all pods within the namespace, whether they are in state ready.

Whether only pods with label healthz should be considered for checking readiness can be configured with config `enablePodLabelHealthzFilter`.