### PR TITLE
use separate cert and key files

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/client/rest/KubernetesClient.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/client/rest/KubernetesClient.groovy
@@ -71,10 +71,10 @@ class KubernetesClient<RESPONSE> {
 
     private KeyStore getKeyStore() {
         Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider())
-        X509Certificate cert = (X509Certificate) (new PEMReader((new StringReader(kubernetesConfig.kubernetesClientCertificate)))).readObject()
+        X509Certificate cert = (X509Certificate) (new PEMReader((new StringReader(new File(kubernetesConfig.kubernetesClientCertificate).text)))).readObject()
         keyStore.load(null, "".toCharArray())
         keyStore.setCertificateEntry("", cert)
-        keyStore.setKeyEntry("1", ((KeyPair) (new PEMReader(new StringReader(kubernetesConfig.kubernetesClientKey))).readObject()).getPrivate(), "".toCharArray(), createCertChain(cert))
+        keyStore.setKeyEntry("1", ((KeyPair) (new PEMReader(new StringReader(new File(kubernetesConfig.kubernetesClientKey).text))).readObject()).getPrivate(), "".toCharArray(), createCertChain(cert))
         return keyStore
     }
 

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -66,9 +66,8 @@ com.swisscom.cloud.sb.broker:
     kubernetes:
       kubernetesHost: "kubernetes-service-api.service.consul"
       kubernetesPort: "6443"
-      kubernetesClientCertificate: |
-
-      kubernetesClientKey: |
+      kubernetesClientCertificate: '/var/vcap/jobs/servicebroker/config/certs/kubernetes_client.crt'
+      kubernetesClientKey: '/var/vcap/jobs/servicebroker/config/certs/kubernetes_client.key'
 
     kubernetes.redis.v1:
       kubernetesRedisHost:


### PR DESCRIPTION
From an operational point of view it's easier to manage certificates and keys in separate files.