### PR TITLE
make sure k8s namespace is deleted

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/KubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/KubernetesFacade.groovy
@@ -14,4 +14,6 @@ trait KubernetesFacade {
 
     abstract boolean isKubernetesDeploymentSuccessful(String serviceInstanceGuid)
 
+    abstract boolean isKubernetesNamespaceDeleted(String serviceInstanceGuid)
+
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
@@ -26,8 +26,10 @@ import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.util.Pair
 import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Component
+import org.springframework.web.client.HttpStatusCodeException
 
 @Component
 @Slf4j
@@ -83,8 +85,12 @@ class KubernetesFacadeRedis extends AbstractKubernetesFacade implements SystemBa
     }
 
     void deprovision(DeprovisionRequest request) {
-        kubernetesClient.exchange(EndpointMapper.INSTANCE.getEndpointUrlByType("Namespace").getFirst() + "/" + request.serviceInstanceGuid,
-                HttpMethod.DELETE, "", Object.class)
+        try {
+            kubernetesClient.exchange(EndpointMapper.INSTANCE.getEndpointUrlByType("Namespace").getFirst() + "/" + request.serviceInstanceGuid,
+                    HttpMethod.DELETE, "", Object.class)
+        } catch (HttpStatusCodeException e) {
+            if (e.statusCode != HttpStatus.NOT_FOUND) throw e
+        }
     }
 
     private Collection<ServiceDetail> buildServiceDetailsList(String redisPassword, List<ResponseEntity> responses) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
@@ -90,6 +90,9 @@ class KubernetesFacadeRedis extends AbstractKubernetesFacade implements SystemBa
                     HttpMethod.DELETE, "", Object.class)
         } catch (HttpStatusCodeException e) {
             if (e.statusCode != HttpStatus.NOT_FOUND) throw e
+            else {
+                log.debug("404: Tried to delete namespace " + request.serviceInstanceGuid + " which was not found. Error Message:" + e.toString())
+            }
         }
     }
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/service/KubernetesRedisServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/service/KubernetesRedisServiceProvider.groovy
@@ -97,6 +97,7 @@ class KubernetesRedisServiceProvider extends AsyncServiceProvider<KubernetesRedi
     @VisibleForTesting
     private StateMachine createDeprovisionStateMachine() {
         StateMachine stateMachine = new StateMachine([KubernetesServiceDeprovisionState.KUBERNETES_NAMESPACE_DELETION,
+                                                      KubernetesServiceDeprovisionState.CHECK_NAMESPACE_DELETION_SUCCESSFUL,
                                                       KubernetesServiceDeprovisionState.UNREGISTER_SHIELD_SYSTEM_BACKUP])
         stateMachine.addAll([KubernetesServiceDeprovisionState.DEPROVISION_SUCCESS])
         return stateMachine

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/service/state/KubernetesServiceDeprovisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/service/state/KubernetesServiceDeprovisionState.groovy
@@ -22,6 +22,15 @@ enum KubernetesServiceDeprovisionState implements ServiceStateWithAction<Kuberne
         }
     }),
 
+    CHECK_NAMESPACE_DELETION_SUCCESSFUL(LastOperation.Status.IN_PROGRESS, new OnStateChange<KubernetesServiceStateMachineContext>
+    () {
+        @Override
+        StateChangeActionResult triggerAction(KubernetesServiceStateMachineContext stateContext) {
+            return new StateChangeActionResult(
+                    go2NextState: stateContext.kubernetesFacade.isKubernetesNamespaceDeleted(stateContext.lastOperationJobContext.deprovisionRequest.serviceInstanceGuid))
+        }
+    }),
+
     UNREGISTER_SHIELD_SYSTEM_BACKUP(LastOperation.Status.IN_PROGRESS, new OnStateChange<KubernetesServiceStateMachineContext>
     () {
         @Override


### PR DESCRIPTION
**Motivation**
When a k8s service instance gets deleted we want to make sure the deletion actually worked. Furthermore deleting service instances which do not exist in the first place, should work without any errors.

**Description**
As we are deleting service instances by deleting namespaces, we simply check if getting the namespace returns a 404 status code. For that step there's the new state `CHECK_NAMESPACE_DELETION_SUCCESSFUL`.