### PR TITLE
All service instance provision requests are saved

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/FirstAsyncProvisioningStepFailsFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/FirstAsyncProvisioningStepFailsFunctionalSpec.groovy
@@ -1,0 +1,31 @@
+package com.swisscom.cloud.sb.broker.functional
+
+import com.swisscom.cloud.sb.broker.services.common.ServiceProviderLookup
+import com.swisscom.cloud.sb.broker.util.test.DummyFailingServiceProvider
+import com.swisscom.cloud.sb.client.model.LastOperationState
+
+class FirstAsyncProvisioningStepFailsFunctionalSpec extends BaseFunctionalSpec {
+
+    def setup() {
+        serviceLifeCycler.createServiceIfDoesNotExist('AsyncDummyFailing', ServiceProviderLookup.findInternalName(DummyFailingServiceProvider))
+    }
+
+    def cleanupSpec() {
+        serviceLifeCycler.cleanup()
+    }
+
+    def "Service Instance is created when async provision request returned HttpStatus.ACCEPTED even first async step fails"() {
+        when:
+        serviceLifeCycler.createServiceInstanceAndAssert(DummyFailingServiceProvider.RETRY_INTERVAL_IN_SECONDS * 4, true, true, ['delay': String.valueOf(DummyFailingServiceProvider.RETRY_INTERVAL_IN_SECONDS)])
+        then:
+        serviceLifeCycler.getServiceInstanceStatus().state == LastOperationState.FAILED
+    }
+
+    def "Failed Service Instance can be deleted"() {
+        when:
+        serviceLifeCycler.deleteServiceInstanceAndAssert(true, DummyFailingServiceProvider.RETRY_INTERVAL_IN_SECONDS * 4)
+        then:
+        noExceptionThrown()
+        serviceLifeCycler.getServiceInstanceStatus().state == LastOperationState.SUCCEEDED
+    }
+}

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningPersistenceService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningPersistenceService.groovy
@@ -87,10 +87,11 @@ class ProvisioningPersistenceService {
         }
     }
 
-    def updateServiceInstanceCompletion(ServiceInstance instance, boolean completed) {
+    ServiceInstance updateServiceInstanceCompletion(ServiceInstance instance, boolean completed) {
         instance = serviceInstanceRepository.merge(instance)
         instance.completed = completed
         serviceInstanceRepository.save(instance)
+        return instance
     }
 
     def markServiceInstanceAsDeleted(ServiceInstance instance) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningPersistenceService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningPersistenceService.groovy
@@ -39,13 +39,18 @@ class ProvisioningPersistenceService {
         deprovisionRequestRepository.save(deprovisionRequest)
     }
 
-    def ServiceInstance createServiceInstance(ProvisionRequest provisionRequest, ProvisionResponse provisionResponse) {
+    def ServiceInstance createServiceInstance(ProvisionRequest provisionRequest) {
         ServiceInstance instance = new ServiceInstance()
         instance.guid = provisionRequest.serviceInstanceGuid
         instance.org = provisionRequest.organizationGuid
         instance.space = provisionRequest.spaceGuid
-        instance.completed = !provisionResponse.isAsync
         instance.plan = provisionRequest.plan
+        serviceInstanceRepository.save(instance)
+    }
+
+    def ServiceInstance createServiceInstance(ProvisionRequest provisionRequest, ProvisionResponse provisionResponse) {
+        ServiceInstance instance = createServiceInstance(provisionRequest)
+        instance.completed = !provisionResponse.isAsync
 
         return updateServiceDetails(provisionResponse.details, instance)
     }
@@ -60,7 +65,7 @@ class ProvisioningPersistenceService {
                 serviceDetailRepository.save(detail)
                 instance.details.add(detail)
         }
-        return serviceInstanceRepository.save(instance)
+        serviceInstanceRepository.save(instance)
     }
 
     private void removeExistingServiceDetailsForKey(ServiceDetail newServiceDetail, ServiceInstance instance) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
@@ -26,9 +26,7 @@ class ProvisioningService {
         log.trace("Provision request:${provisionRequest.toString()}")
         handleAsyncClientRequirement(provisionRequest.plan, provisionRequest.acceptsIncomplete)
         ProvisionResponse provisionResponse = serviceProviderLookup.findServiceProvider(provisionRequest.plan).provision(provisionRequest)
-        if (!provisionResponse.isAsync) {
-            provisioningPersistenceService.createServiceInstance(provisionRequest, provisionResponse)
-        }
+        provisioningPersistenceService.createServiceInstance(provisionRequest, provisionResponse)
         return provisionResponse
     }
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
@@ -2,6 +2,7 @@ package com.swisscom.cloud.sb.broker.provisioning
 
 import com.swisscom.cloud.sb.broker.error.ErrorCode
 import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
+import com.swisscom.cloud.sb.broker.model.LastOperation
 import com.swisscom.cloud.sb.broker.model.Plan
 import com.swisscom.cloud.sb.broker.model.ProvisionRequest
 import com.swisscom.cloud.sb.broker.services.common.ServiceProviderLookup
@@ -25,8 +26,9 @@ class ProvisioningService {
     ProvisionResponse provision(ProvisionRequest provisionRequest) {
         log.trace("Provision request:${provisionRequest.toString()}")
         handleAsyncClientRequirement(provisionRequest.plan, provisionRequest.acceptsIncomplete)
+        def instance = provisioningPersistenceService.createServiceInstance(provisionRequest)
         ProvisionResponse provisionResponse = serviceProviderLookup.findServiceProvider(provisionRequest.plan).provision(provisionRequest)
-        provisioningPersistenceService.createServiceInstance(provisionRequest, provisionResponse)
+        provisioningPersistenceService.updateServiceDetails(provisionResponse.details, instance)
         return provisionResponse
     }
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
@@ -28,6 +28,7 @@ class ProvisioningService {
         handleAsyncClientRequirement(provisionRequest.plan, provisionRequest.acceptsIncomplete)
         def instance = provisioningPersistenceService.createServiceInstance(provisionRequest)
         ProvisionResponse provisionResponse = serviceProviderLookup.findServiceProvider(provisionRequest.plan).provision(provisionRequest)
+        instance = provisioningPersistenceService.updateServiceInstanceCompletion(instance, !provisionResponse.isAsync)
         provisioningPersistenceService.updateServiceDetails(provisionResponse.details, instance)
         return provisionResponse
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummyFailingServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummyFailingServiceProvider.groovy
@@ -1,0 +1,24 @@
+package com.swisscom.cloud.sb.broker.util.test
+
+import com.google.common.base.Optional
+import com.swisscom.cloud.sb.broker.provisioning.async.AsyncOperationResult
+import com.swisscom.cloud.sb.broker.provisioning.lastoperation.LastOperationJobContext
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+class DummyFailingServiceProvider extends DummyServiceProvider {
+
+    @Override
+    AsyncOperationResult requestProvision(LastOperationJobContext context) {
+        throw new RuntimeException("This must crash")
+        return new AsyncOperationResult()
+    }
+
+    @Override
+    Optional<AsyncOperationResult> requestDeprovision(LastOperationJobContext context) {
+        return Optional.of(processOperationResultBasedOnIfEnoughTimeHasElapsed(context, DEFAULT_PROCESSING_DELAY_IN_SECONDS))
+    }
+}
+

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummyServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummyServiceProvider.groovy
@@ -57,7 +57,6 @@ class DummyServiceProvider implements ServiceProvider, AsyncServiceProvisioner, 
     @Override
     ProvisionResponse provision(ProvisionRequest request) {
         if (request.acceptsIncomplete) {
-            provisioningPersistenceService.createServiceInstance(request, new ProvisionResponse(isAsync: true))
             asyncProvisioningService.scheduleProvision(new ProvisioningjobConfig(ServiceProvisioningJob.class, request, RETRY_INTERVAL_IN_SECONDS, 5))
             return new ProvisionResponse(details: [], isAsync: true)
         } else {
@@ -80,7 +79,7 @@ class DummyServiceProvider implements ServiceProvider, AsyncServiceProvisioner, 
         return processOperationResultBasedOnIfEnoughTimeHasElapsed(context, DEFAULT_PROCESSING_DELAY_IN_SECONDS)
     }
 
-    private AsyncOperationResult processOperationResultBasedOnIfEnoughTimeHasElapsed(LastOperationJobContext context, int delay) {
+    protected AsyncOperationResult processOperationResultBasedOnIfEnoughTimeHasElapsed(LastOperationJobContext context, int delay) {
         if (context.provisionRequest?.parameters) {
             Map<String, Object> params = new ObjectMapper().readValue(context.provisionRequest.parameters, new TypeReference<Map<String, Object>>() {
             })

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningServiceSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningServiceSpec.groovy
@@ -81,7 +81,7 @@ class ProvisioningServiceSpec extends Specification {
         when:
         def result = provisioningService.provision(provisionRequest)
         then:
-        createServiceInstanceCalled == false
+        createServiceInstanceCalled == true
         result.isAsync == true
     }
 

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningServiceSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningServiceSpec.groovy
@@ -37,8 +37,12 @@ class ProvisioningServiceSpec extends Specification {
         and:
         def createServiceInstanceCalled = false
         def provisioningPersistenceService = Mock(ProvisioningPersistenceService)
-        provisioningPersistenceService.createServiceInstance(_, _) >> {
+        provisioningPersistenceService.createServiceInstance(_) >> {
             createServiceInstanceCalled = true; Mock(ServiceInstance)
+        }
+        def updateServiceInstanceCalled = false
+        provisioningPersistenceService.updateServiceDetails(_, _) >> {
+            updateServiceInstanceCalled = true; Mock(ServiceInstance)
         }
         provisioningService.provisioningPersistenceService = provisioningPersistenceService
 
@@ -52,6 +56,7 @@ class ProvisioningServiceSpec extends Specification {
         def result = provisioningService.provision(provisionRequest)
         then:
         createServiceInstanceCalled == true
+        updateServiceInstanceCalled == true
         result.isAsync == false
     }
 
@@ -66,8 +71,12 @@ class ProvisioningServiceSpec extends Specification {
         and:
         def createServiceInstanceCalled = false
         def provisioningPersistenceService = Mock(ProvisioningPersistenceService)
-        provisioningPersistenceService.createServiceInstance(_, _) >> {
+        provisioningPersistenceService.createServiceInstance(_) >> {
             createServiceInstanceCalled = true; Mock(ServiceInstance)
+        }
+        def updateServiceInstanceCalled = false
+        provisioningPersistenceService.updateServiceDetails(_, _) >> {
+            updateServiceInstanceCalled = true; Mock(ServiceInstance)
         }
         provisioningService.provisioningPersistenceService = provisioningPersistenceService
 
@@ -82,6 +91,7 @@ class ProvisioningServiceSpec extends Specification {
         def result = provisioningService.provision(provisionRequest)
         then:
         createServiceInstanceCalled == true
+        updateServiceInstanceCalled == true
         result.isAsync == true
     }
 


### PR DESCRIPTION
**Motivation**
While testing kubernetes services, we experienced issues with some API calls. These led to deployment failures, which could not be resolved by requesting the service instance deletion, as OSB had not saved the service instance in the database. For async services this is done after the first step, which already partly failed.

**Description**
With this change, the service instance gets saved whether it will succeed or not.