### PR TITLE
fix race condition in Kubernetes Redis provision

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
@@ -44,7 +44,8 @@ class KubernetesFacadeRedis extends AbstractKubernetesFacade<KubernetesRedisConf
                 (KubernetesRedisTemplateConstants.SLAVEOF_COMMAND.getValue()): slaveofCommand,
                 (KubernetesRedisTemplateConstants.CONFIG_COMMAND.getValue()) : configCommand
         ]
-        kubernetesServiceConfig.redisConfigurationDefaults << planBindings << serviceDetailBindings << otherBindings
+        // Make copy of redisConfigurationDefaults Map for thread safety
+        (new HashMap<String,String>(kubernetesServiceConfig.redisConfigurationDefaults)) << planBindings << serviceDetailBindings << otherBindings
     }
 
     @Override


### PR DESCRIPTION
Writing to injected objects is not thread safe.
This fix makes a copy of the injected map and pushes the remaining maps to the copy.