### PR TITLE
use OpenAPIV3Parser to return OpenAPI 3.0 definition

### DIFF
--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     compile('org.pacesys.openstack4j.connectors:openstack4j-httpclient:2.20')
     compile group: 'org.bouncycastle', name: 'bcprov-jdk16', version: '1.46'
     compile 'com.networknt:json-schema-validator:0.1.17'
+    compile('io.swagger.parser.v3:swagger-parser:2.0.0-rc3')
     compile project(':model')
     compile project(':client')
     // The dependency to tomcat 7.x can be removed as soon as deployment onto Tomcat is not required any more.

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/extensions/ExtensionProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/extensions/ExtensionProvider.groovy
@@ -34,7 +34,7 @@ trait ExtensionProvider{
     abstract Collection<Extension> buildExtensions()
 
     String getApi(){
-        getApi(["service-definition-controller"])
+        getApi(null)
     }
 
     String getApi(List<String> tags, String url = "http://localhost:${env.getProperty("server.port")}${env.getProperty("server.contextPath")}/v2/api-docs") {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/extensions/ExtensionProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfextensions/extensions/ExtensionProvider.groovy
@@ -4,8 +4,16 @@ import com.swisscom.cloud.sb.broker.async.job.JobConfig
 import com.swisscom.cloud.sb.broker.async.job.JobManager
 import com.swisscom.cloud.sb.broker.async.job.JobStatus
 import com.swisscom.cloud.sb.broker.backup.shield.dto.TaskDto
+import com.swisscom.cloud.sb.broker.config.ApplicationConfiguration
 import groovy.util.logging.Slf4j
+import io.swagger.v3.core.util.Json
+import io.swagger.v3.core.util.Yaml
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Paths
+import io.swagger.v3.parser.OpenAPIV3Parser
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.env.Environment
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -20,23 +28,35 @@ trait ExtensionProvider{
     @Autowired
     protected JobManager jobManager
 
+    @Autowired
+    Environment env
+
     abstract Collection<Extension> buildExtensions()
 
     String getApi(){
-        RestTemplate restTemplate = new RestTemplate()
+        getApi(["service-definition-controller"])
+    }
 
-        String swaggerJson = restTemplate.getForEntity("http://localhost:8080/v2/api-docs", String.class).body
+    String getApi(List<String> tags, String url = "http://localhost:${env.getProperty("server.port")}${env.getProperty("server.contextPath")}/v2/api-docs") {
+        OpenAPI openAPI = new OpenAPIV3Parser().read(url)
+        if (tags) {
+            openAPI.setPaths(filterPathsByTags(openAPI, tags))
+        }
+        Json.pretty(openAPI)
+    }
 
-        HttpHeaders headers = new HttpHeaders()
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED)
-
-        MultiValueMap<String, String> map= new LinkedMultiValueMap<String, String>()
-        map.add("source", swaggerJson)
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(map, headers)
-        ResponseEntity<String> response = restTemplate.postForEntity( "https://mermade.org.uk/openapi-converter/api/v1/convert", request , String.class )
-
-        return response.body - "<html><body><pre>"
+    private Paths filterPathsByTags(OpenAPI openAPI, List<String> tags) {
+        Paths pathsToReturn = new Paths()
+        for (path in openAPI.getPaths()) {
+            for (def operation : path.getValue().readOperations()) {
+                for (String tag : tags) {
+                    if (operation.getTags().contains(tag)) {
+                        pathsToReturn.addPathItem(path.getKey(), path.getValue())
+                    }
+                }
+            }
+        }
+        pathsToReturn
     }
 
     //The following methods are required for asynchronous extensions.


### PR DESCRIPTION
Instead of using the free external provider https://mermade.org.uk we'll use the swagger-parser 2.0.0-rc3 parser. This library provides an easy to use conversion from 2.0 to 3.0.

Also make it possible to filter by tags.