### PR TITLE
Support changing Service Bindings

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/binding/ServiceBindingPersistenceService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/binding/ServiceBindingPersistenceService.groovy
@@ -49,7 +49,18 @@ class ServiceBindingPersistenceService {
         return serviceBinding
     }
 
-    public void delete(ServiceBinding serviceBinding, ServiceInstance serviceInstance) {
+    ServiceBinding update(ServiceBinding serviceBinding) {
+        serviceBindingRepository.save(serviceBinding)
+        serviceBinding.details?.each {
+            ServiceDetail detail ->
+                serviceDetailRepository.save(detail)
+        }
+        serviceBindingRepository.save(serviceBinding)
+        return serviceBinding
+    }
+
+
+    void delete(ServiceBinding serviceBinding, ServiceInstance serviceInstance) {
         ServiceInstance serviceInstance_new = serviceInstanceRepository.merge(serviceInstance)
         serviceInstance_new.bindings.remove(serviceBinding)
         serviceInstanceRepository.save(serviceInstance_new)
@@ -62,4 +73,6 @@ class ServiceBindingPersistenceService {
         }
         serviceBindingRepository.delete(serviceBinding_new)
     }
+
+
 }


### PR DESCRIPTION
*Why support changing service bindings*
Certain custom actions are based on service bindings. As these allow to change details and credentials, the bindings have to be updateable.