### PR TITLE
return parameters and avoid nesting credentials in json

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BindingParametersFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BindingParametersFunctionalSpec.groovy
@@ -64,6 +64,7 @@ class BindingParametersFunctionalSpec extends BaseFunctionalSpec {
         noExceptionThrown()
         bindingResponse != null
         bindingResponse.body.credentials != null
+        bindingResponse.body.parameters != null
     }
 
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/ServiceInstanceBindingDtoConverter.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/ServiceInstanceBindingDtoConverter.groovy
@@ -3,20 +3,22 @@ package com.swisscom.cloud.sb.broker.cfapi.converter
 import com.swisscom.cloud.sb.broker.binding.ServiceInstanceBindingResponseDto
 import com.swisscom.cloud.sb.broker.converter.AbstractGenericConverter
 import com.swisscom.cloud.sb.broker.model.ServiceBinding
-import groovy.transform.CompileStatic
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+import groovy.util.logging.Slf4j
 import org.springframework.stereotype.Component
 
-@CompileStatic
+@Slf4j
 @Component
 class ServiceInstanceBindingDtoConverter extends AbstractGenericConverter<ServiceBinding, ServiceInstanceBindingResponseDto> {
 
     @Override
     void convert(ServiceBinding source, ServiceInstanceBindingResponseDto prototype) {
-        prototype.credentials = source.credentials
-        prototype.parameters = null // TODO
+        Object credentials = new JsonSlurper().parseText(source.credentials).credentials
+        prototype.credentials = new JsonBuilder(credentials).toString()
+        prototype.parameters = source.parameters
         prototype.routeServiceUrl = null
         prototype.syslogDrainUrl = null
         prototype.volumeMounts = null
     }
-
 }


### PR DESCRIPTION
Since we save the credentials string with like this

`"credentials": {
  "foo": "bar"
}`

The fetch return for a service_bindings looks like this:
`"credentials": "\"credentials\": {\n\"foo\": \"bar\"\n}"`

This nesting of credentials does not make sense, with this change credentials looks like this:
`"credentials": "{\"foo\": \"bar\"}"`

Furthermore parameters are now also returned in the service_binding fetch.