### PR TITLE
support configuring bosh-templates in application.yml

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshConfig.groovy
@@ -8,5 +8,4 @@ trait BoshConfig implements Config {
     String boshDirectorBaseUrl
     String boshDirectorUsername
     String boshDirectorPassword
-    Map<String, String> boshManifestTemplates
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshConfig.groovy
@@ -8,4 +8,5 @@ trait BoshConfig implements Config {
     String boshDirectorBaseUrl
     String boshDirectorUsername
     String boshDirectorPassword
+    Map<String, String> boshManifestTemplates
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -128,11 +128,12 @@ class BoshFacade {
     }
 
     private String readTemplateContent(String templateIdentifier, String version = "1.0.0") {
+        Preconditions.checkNotNull(templateIdentifier, 'Need a valid template name!')
         try {
             String template = templateConfig.getTemplateForServiceKey(templateIdentifier, version)[0]
             return template
         } catch (NoSuchElementException e) {
-            Preconditions.checkNotNull(templateIdentifier, 'Need a valid template name!')
+            // Fallback method which was used by BOSH deployments
             String fileName = templateIdentifier + (templateIdentifier.endsWith('.yml') ? '' : '.yml')
             File file = new File(serviceConfig.boshManifestFolder, fileName)
             if (file.exists()) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeFactory.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeFactory.groovy
@@ -1,6 +1,7 @@
 package com.swisscom.cloud.sb.broker.services.bosh
 
 import com.swisscom.cloud.sb.broker.services.bosh.client.BoshClientFactory
+import com.swisscom.cloud.sb.broker.services.common.TemplateConfig
 import com.swisscom.cloud.sb.broker.services.mongodb.enterprise.openstack.OpenStackClientFactory
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
@@ -12,15 +13,17 @@ class BoshFacadeFactory {
     private final BoshClientFactory boshClientFactory
     private final OpenStackClientFactory openStackClientFactory
     private final BoshTemplateFactory boshTemplateFactory
+    private final TemplateConfig templateConfig
 
     @Autowired
-    BoshFacadeFactory(BoshClientFactory boshClientFactory, OpenStackClientFactory openStackClientFactory, BoshTemplateFactory boshTemplateFactory) {
+    BoshFacadeFactory(BoshClientFactory boshClientFactory, OpenStackClientFactory openStackClientFactory, BoshTemplateFactory boshTemplateFactory, TemplateConfig templateConfig) {
         this.boshClientFactory = boshClientFactory
         this.openStackClientFactory = openStackClientFactory
         this.boshTemplateFactory = boshTemplateFactory
+        this.templateConfig = templateConfig
     }
 
     BoshFacade build(BoshBasedServiceConfig boshBasedServiceConfig) {
-        return new BoshFacade(boshClientFactory, openStackClientFactory, boshBasedServiceConfig, boshTemplateFactory)
+        return new BoshFacade(boshClientFactory, openStackClientFactory, boshBasedServiceConfig, boshTemplateFactory, templateConfig)
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/common/TemplateConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/common/TemplateConfig.groovy
@@ -1,4 +1,4 @@
-package com.swisscom.cloud.sb.broker.services.kubernetes.config
+package com.swisscom.cloud.sb.broker.services.common
 
 import com.swisscom.cloud.sb.broker.config.Config
 import org.springframework.boot.context.properties.ConfigurationProperties

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/templates/KubernetesTemplateManager.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/templates/KubernetesTemplateManager.groovy
@@ -1,7 +1,6 @@
 package com.swisscom.cloud.sb.broker.services.kubernetes.templates
 
-import com.swisscom.cloud.sb.broker.services.kubernetes.config.AbstractKubernetesServiceConfig
-import com.swisscom.cloud.sb.broker.services.kubernetes.config.TemplateConfig
+import com.swisscom.cloud.sb.broker.services.common.TemplateConfig
 import groovy.transform.CompileStatic
 import groovy.util.logging.Log4j
 import org.springframework.beans.factory.annotation.Autowired

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeFactorySpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeFactorySpec.groovy
@@ -1,6 +1,7 @@
 package com.swisscom.cloud.sb.broker.services.bosh
 
 import com.swisscom.cloud.sb.broker.services.bosh.client.BoshClientFactory
+import com.swisscom.cloud.sb.broker.services.common.TemplateConfig
 import com.swisscom.cloud.sb.broker.services.mongodb.enterprise.openstack.OpenStackClientFactory
 import spock.lang.Specification
 
@@ -11,7 +12,8 @@ class BoshFacadeFactorySpec extends Specification {
         BoshClientFactory boshClientFactory = Mock(BoshClientFactory)
         OpenStackClientFactory openStackClientFactory = Mock(OpenStackClientFactory)
         BoshTemplateFactory boshTemplateFactory = Mock(BoshTemplateFactory)
-        BoshFacadeFactory boshFacadeFactory = new BoshFacadeFactory(boshClientFactory, openStackClientFactory, boshTemplateFactory)
+        TemplateConfig templateConfig = Mock(TemplateConfig)
+        BoshFacadeFactory boshFacadeFactory = new BoshFacadeFactory(boshClientFactory, openStackClientFactory, boshTemplateFactory, templateConfig)
 
         BoshBasedServiceConfig boshBasedServiceConfig = new DummyConfig()
         when:
@@ -22,6 +24,5 @@ class BoshFacadeFactorySpec extends Specification {
         result.boshClientFactory == boshClientFactory
         result.serviceConfig == boshBasedServiceConfig
         result.boshTemplateFactory == boshTemplateFactory
-
     }
 }


### PR DESCRIPTION
**Motivation**
We want to be able to use the application.yml as the single source of truth for open-service-broker configuration.

**Problem**
bosh-templates have to be configured as separate files.

**Proposal**
Use the same structure we already use for kubernetes services and add the configuration to the application.yml.