### PR TITLE
return 410 for non existing service instances and binding

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BaseController.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BaseController.groovy
@@ -64,7 +64,7 @@ abstract class BaseController {
     protected ServiceInstance getAndCheckServiceInstance(String serviceInstanceId) {
         ServiceInstance serviceInstance = serviceInstanceRepository.findByGuid(serviceInstanceId)
         if (!serviceInstance) {
-            ErrorCode.SERVICE_INSTANCE_NOT_FOUND.throwNew("ID = ${serviceInstanceId}")
+            ErrorCode.SERVICE_INSTANCE_GONE.throwNew("ID = ${serviceInstanceId}")
         }
         if (serviceInstance.deleted) {
             ErrorCode.SERVICE_INSTANCE_DELETED.throwNew("ID = ${serviceInstanceId}")

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BindingController.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BindingController.groovy
@@ -114,7 +114,7 @@ class BindingController extends BaseController {
         return bindRequest
     }
 
-    @ApiOperation(value = "Delete service instance")
+    @ApiOperation(value = "Delete service binding")
     @RequestMapping(value = '/v2/service_instances/{service_instance}/service_bindings/{id}', method = RequestMethod.DELETE)
     def unbind(@PathVariable('service_instance') String serviceInstanceId,
                @PathVariable('id') String bindingGuid,

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BindingController.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BindingController.groovy
@@ -139,8 +139,8 @@ class BindingController extends BaseController {
                                                                 @PathVariable("bindingId") String bindingGuid) {
         checkServiceBinding(bindingGuid)
         def serviceBinding = serviceBindingRepository.findByGuid(bindingGuid)
-        if (serviceBinding.serviceInstance.guid != serviceInstanceGuid || !serviceBinding.serviceInstance.plan.service.bindingsRetrievable) {
-            ErrorCode.SERVICE_BINDING_NOT_FOUND.throwNew()
+        if (!serviceBinding.serviceInstance.plan.service.bindingsRetrievable) {
+            ErrorCode.SERVICE_BINDING_NOT_RETRIEVABLE.throwNew()
         }
         ServiceProvider serviceProvider = serviceProviderLookup.findServiceProvider(serviceBinding.serviceInstance.plan)
         if (!(serviceProvider instanceof FetchServiceBindingProvider)) {
@@ -154,7 +154,7 @@ class BindingController extends BaseController {
     private ServiceBinding checkServiceBinding(String bindingGuid) {
         ServiceBinding serviceBinding = serviceBindingRepository.findByGuid(bindingGuid)
         if (!serviceBinding) {
-            ErrorCode.SERVICE_BINDING_NOT_FOUND.throwNew()
+            ErrorCode.SERVICE_BINDING_GONE.throwNew()
         }
         return serviceBinding
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/error/ErrorCode.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/error/ErrorCode.groovy
@@ -10,9 +10,9 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 enum ErrorCode {
 
     //TODO get rid of errorCodes
-    SERVICE_INSTANCE_NOT_FOUND("69003", "Service Instance not found", "SC-SB-SI", HttpStatus.GONE),
+    SERVICE_INSTANCE_NOT_FOUND("69003", "Service Instance not found", "SC-SB-SI", HttpStatus.NOT_FOUND),
     SERVICE_INSTANCE_ALREADY_EXISTS("69004", "Service Instance already exists", "SC-SB-SI", HttpStatus.CONFLICT),
-    SERVICE_BINDING_NOT_FOUND("69005", "Service Binding not found", "SC-SB-SERVICE-BINDING-NOT-FOUND", HttpStatus.GONE),
+    SERVICE_BINDING_NOT_FOUND("69005", "Service Binding not found", "SC-SB-SERVICE-BINDING-NOT-FOUND", HttpStatus.NOT_FOUND),
     SERVICE_BINDING_ALREADY_EXISTS("69006", "Service Binding already exists", "SC-SB-SERVICE-BINDING-ALREADY-EXISTS", HttpStatus.CONFLICT),
     SERVICE_NOT_FOUND("69007", "Service not found", "SC-SB-SERVICE-NOT-FOUND", HttpStatus.BAD_REQUEST),
     PLAN_NOT_FOUND("69008", "Plan not found", "SC-SB-PLAN-NOT-FOUND", HttpStatus.BAD_REQUEST),
@@ -58,7 +58,10 @@ enum ErrorCode {
     INVALID_PLAN_SCHEMAS("69049", "Plan schemas invalid", "SC-SB-PLAN-SCHEMA-INVALID", HttpStatus.BAD_REQUEST),
     SERVICEPROVIDER_INCORRECT_PARAMETERS("69050", "ServiceProvider detected wrong Parameters", "SC-SB-SERVICEPROVIDER-PARAMETERS", HttpStatus.BAD_REQUEST),
     SERVICEPROVIDER_INTERNAL_ERROR("69051", "Serviceprovider for the selected Plan encountered an Error", "SC-SB-SERVICEPROVIDER-INTERNAL", HttpStatus.INTERNAL_SERVER_ERROR),
-    CLIENT_INVALID_REQUEST("69052","Request Validation failed","SC-SB-SERVICEPROVIDER-CLIENT-INVALID",HttpStatus.BAD_REQUEST)
+    CLIENT_INVALID_REQUEST("69052","Request Validation failed","SC-SB-SERVICEPROVIDER-CLIENT-INVALID",HttpStatus.BAD_REQUEST),
+    SERVICE_INSTANCE_GONE("69053", "Service Instance gone", "SC-SB-SI", HttpStatus.GONE),
+    SERVICE_BINDING_GONE("69054", "Service Binding gone", "SC-SB-SERVICE-BINDING-NOT-FOUND", HttpStatus.GONE),
+    SERVICE_BINDING_NOT_RETRIEVABLE("69055", "Service Binding not retrievable", "SC-SB-SERVICE-BINDING-NOT-RETRIEVABLE", HttpStatus.BAD_REQUEST)
 
     final String code
     final String errorCode

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/error/ErrorCode.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/error/ErrorCode.groovy
@@ -10,9 +10,9 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 enum ErrorCode {
 
     //TODO get rid of errorCodes
-    SERVICE_INSTANCE_NOT_FOUND("69003", "Service Instance not found", "SC-SB-SI", HttpStatus.NOT_FOUND),
+    SERVICE_INSTANCE_NOT_FOUND("69003", "Service Instance not found", "SC-SB-SI", HttpStatus.GONE),
     SERVICE_INSTANCE_ALREADY_EXISTS("69004", "Service Instance already exists", "SC-SB-SI", HttpStatus.CONFLICT),
-    SERVICE_BINDING_NOT_FOUND("69005", "Service Binding not found", "SC-SB-SERVICE-BINDING-NOT-FOUND", HttpStatus.NOT_FOUND),
+    SERVICE_BINDING_NOT_FOUND("69005", "Service Binding not found", "SC-SB-SERVICE-BINDING-NOT-FOUND", HttpStatus.GONE),
     SERVICE_BINDING_ALREADY_EXISTS("69006", "Service Binding already exists", "SC-SB-SERVICE-BINDING-ALREADY-EXISTS", HttpStatus.CONFLICT),
     SERVICE_NOT_FOUND("69007", "Service not found", "SC-SB-SERVICE-NOT-FOUND", HttpStatus.BAD_REQUEST),
     PLAN_NOT_FOUND("69008", "Plan not found", "SC-SB-PLAN-NOT-FOUND", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
**Problem**
Currently open-service-broker responds with a 404 when requesting a deprovision or unbinding and the binding or instance can not be found. For platforms relying on the [Open Service Broker API specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md) this leads to an error as it should return a 410 in this case, and the instance or binding can not be deleted.

**Proposal**
As specified by the openservicebrokerapi, return 410 HTTP status code when unbinding/deprovisioning a service binding/instance and the object is not found.