### PR TITLE
Fix status codes for unbinding, deprovision and fetch not existing

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AsyncServiceFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AsyncServiceFunctionalSpec.groovy
@@ -8,6 +8,7 @@ import com.swisscom.cloud.sb.broker.model.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.services.common.ServiceProviderLookup
 import com.swisscom.cloud.sb.broker.util.servicecontext.ServiceContextHelper
 import com.swisscom.cloud.sb.broker.util.test.DummyServiceProvider
+import com.swisscom.cloud.sb.client.model.DeleteServiceInstanceRequest
 import com.swisscom.cloud.sb.client.model.LastOperationState
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.servicebroker.model.CloudFoundryContext
@@ -64,6 +65,23 @@ class AsyncServiceFunctionalSpec extends BaseFunctionalSpec {
         serviceLifeCycler.getServiceInstanceStatus().state == LastOperationState.SUCCEEDED
     }
 
+    def "deprovision not existing async service instance"() {
+        when:
+        serviceBrokerClient.deleteServiceInstance(new DeleteServiceInstanceRequest(UUID.randomUUID().toString(), serviceLifeCycler.cfService.guid, serviceLifeCycler.cfService.plans[0].guid, true))
+
+        then:
+        def ex = thrown(HttpClientErrorException)
+        ex.statusCode == HttpStatus.GONE
+    }
+
+    def "fetch not existing async service instance"() {
+        when:
+        serviceBrokerClient.getServiceInstance(UUID.randomUUID().toString())
+
+        then:
+        def ex = thrown(HttpClientErrorException)
+        ex.statusCode == HttpStatus.NOT_FOUND
+    }
 
     def "provision async service instance"() {
         given:

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AuthenticationFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AuthenticationFunctionalSpec.groovy
@@ -8,7 +8,7 @@ class AuthenticationFunctionalSpec extends BaseFunctionalSpec {
 
     def "catalog controller returns 401 when no credentials provided"() {
         when:
-        def response = new ServiceBrokerClient(appBaseUrl,null,null).getCatalog()
+        new ServiceBrokerClient(appBaseUrl,null,null).getCatalog()
 
         then:
         def ex = thrown(HttpClientErrorException)
@@ -17,7 +17,7 @@ class AuthenticationFunctionalSpec extends BaseFunctionalSpec {
 
     def "catalog controller returns 401 when wrong credentials provided"() {
         when:
-        def response = new ServiceBrokerClient(appBaseUrl,'SomeUsername','WrongPassword').getCatalog()
+        new ServiceBrokerClient(appBaseUrl,'SomeUsername','WrongPassword').getCatalog()
 
         then:
         def ex = thrown(HttpClientErrorException)
@@ -34,7 +34,7 @@ class AuthenticationFunctionalSpec extends BaseFunctionalSpec {
 
     def "catalog controller returns Forbidden 403 when wrong role provided"() {
         when:
-        def response = new ServiceBrokerClient(appBaseUrl, cfExtUser.username, cfExtUser.password).getCatalog()
+        new ServiceBrokerClient(appBaseUrl, cfExtUser.username, cfExtUser.password).getCatalog()
 
         then:
         def ex = thrown(HttpClientErrorException)

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BindingParametersFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BindingParametersFunctionalSpec.groovy
@@ -3,6 +3,7 @@ package com.swisscom.cloud.sb.broker.functional
 import com.swisscom.cloud.sb.broker.model.repository.ServiceBindingRepository
 import com.swisscom.cloud.sb.broker.services.common.ServiceProviderLookup
 import com.swisscom.cloud.sb.broker.util.test.DummySynchronousServiceProvider
+import com.swisscom.cloud.sb.client.model.DeleteServiceInstanceBindingRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
@@ -78,6 +79,41 @@ class BindingParametersFunctionalSpec extends BaseFunctionalSpec {
         bindingResponse.body.parameters != null
     }
 
+    def "provision async service instance and fetch non existing binding"() {
+        given:
+        serviceLifeCycler.createServiceIfDoesNotExist('SyncDummyInstancesRetrievable', ServiceProviderLookup.findInternalName(DummySynchronousServiceProvider.class), null, null, null, 0, true, true)
+
+        def serviceInstanceGuid = UUID.randomUUID().toString()
+        def serviceBindingGuid = UUID.randomUUID().toString()
+        serviceLifeCycler.setServiceInstanceId(serviceInstanceGuid)
+        serviceLifeCycler.setServiceBindingId(serviceBindingGuid)
+        serviceLifeCycler.createServiceInstanceAndAssert(0, false, false,)
+
+        when:
+        serviceBrokerClient.getServiceInstanceBinding(serviceInstanceGuid, serviceBindingGuid)
+
+        then:
+        def ex = thrown(HttpClientErrorException)
+        ex.statusCode == HttpStatus.NOT_FOUND
+    }
+
+    def "provision async service instance and unbind non existing binding"() {
+        given:
+        serviceLifeCycler.createServiceIfDoesNotExist('SyncDummyInstancesRetrievable', ServiceProviderLookup.findInternalName(DummySynchronousServiceProvider.class), null, null, null, 0, true, true)
+
+        def serviceInstanceGuid = UUID.randomUUID().toString()
+        def serviceBindingGuid = UUID.randomUUID().toString()
+        serviceLifeCycler.setServiceInstanceId(serviceInstanceGuid)
+        serviceLifeCycler.setServiceBindingId(serviceBindingGuid)
+        serviceLifeCycler.createServiceInstanceAndAssert(0, false, false,)
+
+        when:
+        serviceBrokerClient.deleteServiceInstanceBinding(new DeleteServiceInstanceBindingRequest(serviceInstanceGuid,
+                serviceBindingGuid, serviceLifeCycler.cfService.guid, serviceLifeCycler.cfService.plans[0].guid))
+        then:
+        def ex = thrown(HttpClientErrorException)
+        ex.statusCode == HttpStatus.GONE
+    }
 
     def "deprovision async service instance"() {
         when:


### PR DESCRIPTION
**Problem**
Our status codes are not always correct when fetching, deprovisioning or unbinding and the resource does not exist. This can be problematic if the client relies on correct status codes.

**Proposal**
Make sure return codes are as specified in the [Open Service Broker API specifications](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md).