### PR TITLE
Update service for MongoDB Ent

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -137,7 +137,6 @@ class OpsManagerFacade {
 
     Boolean updateReplicaSet(String groupId, String mongoDbVersion, String featureCompatibilityVersion) {
         updateAutomationConfig(groupId, { AutomationConfigDto automationConfigDto ->
-            automationConfigDto.version = getAndCheckInitialAutomationGoalVersion(groupId) + 1
             automationConfigDto.processes.each { it.featureCompatibilityVersion = featureCompatibilityVersion }
             automationConfigDto.processes.each { it.version = mongoDbVersion }
         })

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -137,6 +137,7 @@ class OpsManagerFacade {
 
     Boolean updateReplicaSet(String groupId, String mongoDbVersion, String featureCompatibilityVersion) {
         updateAutomationConfig(groupId, { AutomationConfigDto automationConfigDto ->
+            automationConfigDto.version = automationConfigDto.version + 1
             automationConfigDto.processes.first().featureCompatibilityVersion = featureCompatibilityVersion
             automationConfigDto.processes.first().version = mongoDbVersion
         })

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -118,12 +118,12 @@ class OpsManagerFacade {
         return true
     }
 
-    def MongoDbEnterpriseDeployment deployStandAlone(String groupId, String database, int port) {
+    MongoDbEnterpriseDeployment deployStandAlone(String groupId, String database, int port) {
         throw new NotImplementedException()
     }
 
     //TODO refactor this method ,passing in too many arguments
-    def MongoDbEnterpriseDeployment deployReplicaSet(String groupId, String database, int port, String healthUser, String healthPassword, String mongoDbVersion, String featureCompatibilityVersion) {
+    MongoDbEnterpriseDeployment deployReplicaSet(String groupId, String database, int port, String healthUser, String healthPassword, String mongoDbVersion, String featureCompatibilityVersion) {
         final List<String> hosts = findHostsForGroup(groupId)
         final List<HostPort> hostPorts = hosts.collect { String host -> new HostPort(host: host, port: port) }
 
@@ -135,7 +135,15 @@ class OpsManagerFacade {
         return deployment
     }
 
-    def MongoDbEnterpriseDeployment deployShard(String groupId, String database, int port) {
+    Boolean updateReplicaSet(String groupId, String mongoDbVersion, String featureCompatibilityVersion) {
+        updateAutomationConfig(groupId, { AutomationConfigDto automationConfigDto ->
+            automationConfigDto.processes.first().featureCompatibilityVersion = featureCompatibilityVersion
+            automationConfigDto.processes.first().version = mongoDbVersion
+        })
+        return true
+    }
+
+    MongoDbEnterpriseDeployment deployShard(String groupId, String database, int port) {
         throw new NotImplementedException()
     }
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -137,7 +137,7 @@ class OpsManagerFacade {
 
     Boolean updateReplicaSet(String groupId, String mongoDbVersion, String featureCompatibilityVersion) {
         updateAutomationConfig(groupId, { AutomationConfigDto automationConfigDto ->
-            automationConfigDto.version = automationConfigDto.version + 1
+            automationConfigDto.version = getAndCheckInitialAutomationGoalVersion(groupId) + 1
             automationConfigDto.processes.each { it.featureCompatibilityVersion = featureCompatibilityVersion }
             automationConfigDto.processes.each { it.version = mongoDbVersion }
         })

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -138,8 +138,8 @@ class OpsManagerFacade {
     Boolean updateReplicaSet(String groupId, String mongoDbVersion, String featureCompatibilityVersion) {
         updateAutomationConfig(groupId, { AutomationConfigDto automationConfigDto ->
             automationConfigDto.version = automationConfigDto.version + 1
-            automationConfigDto.processes.first().featureCompatibilityVersion = featureCompatibilityVersion
-            automationConfigDto.processes.first().version = mongoDbVersion
+            automationConfigDto.processes.each { it.featureCompatibilityVersion = featureCompatibilityVersion }
+            automationConfigDto.processes.each { it.version = mongoDbVersion }
         })
         return true
     }
@@ -335,8 +335,8 @@ class OpsManagerFacade {
         //populateKeyInfo(authenticationDto)
     }
 
-    private void setAuthMechamnismIfNotAlreadySet(AuthenticationDto authenticationDto){
-        if(!authenticationDto.autoAuthMechanism){
+    private void setAuthMechamnismIfNotAlreadySet(AuthenticationDto authenticationDto) {
+        if (!authenticationDto.autoAuthMechanism) {
             authenticationDto.autoAuthMechanism = AUTH_MECHANISM_MONGODB_CR
         }
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -71,14 +71,14 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         String findTargetCompatibillityVersion(LastOperationJobContext context) {
             if (context.updateRequest != null) {
                 if (context.updateRequest.parameters != null) {
-                    def parsedContext = new JsonSlurper().parse(context.updateRequest.parameters)
+                    def parsedContext = new JsonSlurper().parseText(context.updateRequest.parameters)
                     if (parsedContext["featureCompatibilityVersion"] != null) {
                         return parsedContext["featureCompatibilityVersion"]
                     }
                 }
             } else if (context.provisionRequest != null) {
                 if (context.provisionRequest.parameters != null) {
-                    def parsedContext = new JsonSlurper().parse(context.provisionRequest.parameters)
+                    def parsedContext = new JsonSlurper().parseText(context.provisionRequest.parameters)
                     if (parsedContext["featureCompatibilityVersion"] != null) {
                         return parsedContext["featureCompatibilityVersion"]
                     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -14,6 +14,7 @@ import com.swisscom.cloud.sb.broker.services.mongodb.enterprise.MongoDbEnterpris
 import com.swisscom.cloud.sb.broker.services.mongodb.enterprise.opsmanager.OpsManagerGroup
 import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailKey
 import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper
+import groovy.json.JsonSlurper
 import groovy.util.logging.Slf4j
 
 import static com.swisscom.cloud.sb.broker.model.ServiceDetail.from
@@ -70,14 +71,16 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         String findTargetCompatibillityVersion(LastOperationJobContext context) {
             if (context.updateRequest != null) {
                 if (context.updateRequest.parameters != null) {
-                    if (context.updateRequest.parameters["featureCompatibilityVersion"] != null) {
-                        return context.updateRequest.parameters["featureCompatibilityVersion"]
+                    def parsedContext = new JsonSlurper().parse(context.updateRequest.parameters)
+                    if (parsedContext["featureCompatibilityVersion"] != null) {
+                        return parsedContext["featureCompatibilityVersion"]
                     }
                 }
             } else if (context.provisionRequest != null) {
                 if (context.provisionRequest.parameters != null) {
-                    if (context.provisionRequest.parameters["featureCompatibilityVersion"] != null) {
-                        return context.provisionRequest.parameters["featureCompatibilityVersion"]
+                    def parsedContext = new JsonSlurper().parse(context.provisionRequest.parameters)
+                    if (parsedContext["featureCompatibilityVersion"] != null) {
+                        return parsedContext["featureCompatibilityVersion"]
                     }
                 }
             }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -51,7 +51,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
             String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
             int initialAutomationVersion = stateContext.opsManagerFacade.getAndCheckInitialAutomationGoalVersion(groupId)
-            MongoDbEnterpriseDeployment deployment = stateContext.opsManagerFacade.deployReplicaSet(groupId, stateContext.lastOperationJobContext.provisionRequest.serviceInstanceGuid,
+            MongoDbEnterpriseDeployment deployment = stateContext.opsManagerFacade.deployReplicaSet(groupId, stateContext.lastOperationJobContext.serviceInstance.guid,
                     ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(ServiceDetailKey.PORT) as int,
                     ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_HEALTH_CHECK_USER),
                     ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_HEALTH_CHECK_PASSWORD),

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -57,7 +57,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
                         go2NextState: stateContext.opsManagerFacade.updateReplicaSet(groupId,
                                 findTargetMongoDBVersion(stateContext),
                                 findTargetCompatibillityVersion(stateContext.lastOperationJobContext)),
-                        details: [from(MONGODB_ENTERPRISE_TARGET_AUTOMATION_GOAL_VERSION, String.valueOf(initialAutomationVersion + 1))])
+                        details: [from(MONGODB_ENTERPRISE_TARGET_AUTOMATION_GOAL_VERSION, String.valueOf(initialAutomationVersion))])
 
             } else if (stateContext.lastOperationJobContext.provisionRequest) {
                 MongoDbEnterpriseDeployment deployment = stateContext.opsManagerFacade.deployReplicaSet(groupId, stateContext.lastOperationJobContext.serviceInstance.guid,

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProviderSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProviderSpec.groovy
@@ -15,10 +15,10 @@ import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailKey
 import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper
 import groovy.json.JsonSlurper
 
-import static MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID
+import static MongoDbEnterpriseProvisionState.PROVISION_SUCCESS
 import static MongoDbEnterpriseDeprovisionState.DISABLE_BACKUP_IF_ENABLED
 import static MongoDbEnterpriseDeprovisionState.UPDATE_AUTOMATION_CONFIG
-import static MongoDbEnterpriseProvisionState.PROVISION_SUCCESS
+import static MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID
 import static ServiceDetail.from
 import static ServiceDetailKey.DATABASE
 
@@ -109,6 +109,18 @@ class MongoDbEnterpriseServiceProviderSpec extends AbstractAsyncServiceProviderS
         def context = new LastOperationJobContext(lastOperation: new LastOperation(internalState: PROVISION_SUCCESS.toString()))
         when:
         def result=serviceProvider.requestProvision(context)
+        then:
+        result
+    }
+
+    def "happy path: requestUpdate"(){
+        given:
+        def context = new LastOperationJobContext(lastOperation: new LastOperation(internalState: PROVISION_SUCCESS.toString()))
+        and:
+        def plan = new Plan()
+        context.updateRequest = new UpdateRequest(previousPlan: plan, plan: plan)
+        when:
+        def result=serviceProvider.requestUpdate(context)
         then:
         result
     }

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/OpsManagerFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/OpsManagerFacadeSpec.groovy
@@ -140,7 +140,7 @@ class OpsManagerFacadeSpec extends Specification {
         opsManagerClient.listAutomationAgents(GROUP_ID) >> [new AutomationAgentDto(hostname: 'host')]
 
         when:
-        def result = opsManagerFacade.deployReplicaSet(GROUP_ID, database, 27000, 'healthuser', 'healthpassword', 'version')
+        def result = opsManagerFacade.deployReplicaSet(GROUP_ID, database, 27000, 'healthuser', 'healthpassword', 'version', "3.4")
 
         then:
         1 * opsManagerClient.updateAutomationConfig(GROUP_ID, config)

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionStateSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionStateSpec.groovy
@@ -71,6 +71,7 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
 
     def "REQUEST_AUTOMATION_UPDATE for a mongodb version specified in plan"() {
         given:
+        //stateContext.lastOperationJobContext.serviceInstance.guid
         def groupId = 'GroupId'
         def port = 666
         def mongodb_enterprise_health_check_user = 'MONGODB_ENTERPRISE_HEALTH_CHECK_USER'
@@ -81,7 +82,8 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
                 serviceInstance: new ServiceInstance(details: [ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID, groupId),
                                                                ServiceDetail.from(ServiceDetailKey.PORT, port.toString()),
                                                                ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_HEALTH_CHECK_PASSWORD, mongodb_enterprise_health_check_password),
-                                                               ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_HEALTH_CHECK_USER, mongodb_enterprise_health_check_user)])
+                                                               ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_HEALTH_CHECK_USER, mongodb_enterprise_health_check_user)],
+                        guid: 'guid')
                 , provisionRequest: new ProvisionRequest(serviceInstanceGuid: 'guid'))
         and:
         def initialAutomationVersion = 1
@@ -123,7 +125,8 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
                 serviceInstance: new ServiceInstance(details: [ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID, groupId),
                                                                ServiceDetail.from(ServiceDetailKey.PORT, port.toString()),
                                                                ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_HEALTH_CHECK_PASSWORD, mongodb_enterprise_health_check_password),
-                                                               ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_HEALTH_CHECK_USER, mongodb_enterprise_health_check_user)])
+                                                               ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_HEALTH_CHECK_USER, mongodb_enterprise_health_check_user)],
+                        guid: 'guid')
                 , provisionRequest: new ProvisionRequest(serviceInstanceGuid: 'guid'))
         and:
         def initialAutomationVersion = 1
@@ -155,7 +158,7 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
         def groupId = 'GroupId'
         def automationVersion = 666
         context.lastOperationJobContext = new LastOperationJobContext(serviceInstance: new ServiceInstance(details: [ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID, groupId),
-                                                                                                                     ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_TARGET_AUTOMATION_GOAL_VERSION, automationVersion.toString())]))
+                                                                                                                     ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_TARGET_AUTOMATION_GOAL_VERSION, automationVersion.toString())]), provisionRequest: new ProvisionRequest())
         and:
         context.opsManagerFacade.isAutomationUpdateComplete(groupId, automationVersion) >> opsManagerResponse
 

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionStateSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionStateSpec.groovy
@@ -76,6 +76,7 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
         def mongodb_enterprise_health_check_user = 'MONGODB_ENTERPRISE_HEALTH_CHECK_USER'
         def mongodb_enterprise_health_check_password = 'MONGODB_ENTERPRISE_HEALTH_CHECK_PASSWORD'
         def mongodb_version = 'Some Version'
+        def feature_compatibility_version = ""
         context.lastOperationJobContext = new LastOperationJobContext(plan: new Plan(parameters: [new Parameter(name: MongoDbEnterpriseProvisionState.PLAN_PARAMETER_MONGODB_VERSION, value: mongodb_version)]),
                 serviceInstance: new ServiceInstance(details: [ServiceDetail.from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID, groupId),
                                                                ServiceDetail.from(ServiceDetailKey.PORT, port.toString()),
@@ -88,7 +89,7 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
 
         and:
         def deployment = new MongoDbEnterpriseDeployment()
-        1 * context.opsManagerFacade.deployReplicaSet(groupId, 'guid', port, mongodb_enterprise_health_check_user, mongodb_enterprise_health_check_password, mongodb_version) >> deployment
+        1 * context.opsManagerFacade.deployReplicaSet(groupId, 'guid', port, mongodb_enterprise_health_check_user, mongodb_enterprise_health_check_password, mongodb_version, feature_compatibility_version) >> deployment
 
         when:
         def result = MongoDbEnterpriseProvisionState.REQUEST_AUTOMATION_UPDATE.triggerAction(context)
@@ -113,6 +114,7 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
         def mongodb_enterprise_health_check_user = 'MONGODB_ENTERPRISE_HEALTH_CHECK_USER'
         def mongodb_enterprise_health_check_password = 'MONGODB_ENTERPRISE_HEALTH_CHECK_PASSWORD'
         def mongodb_version = 'A version from SB Config'
+        def feature_compatibility_version = ""
 
         and:
         context.mongoDbEnterpriseConfig = new MongoDbEnterpriseConfig(mongoDbVersion: mongodb_version)
@@ -129,7 +131,7 @@ class MongoDbEnterpriseProvisionStateSpec extends Specification {
 
         and:
         def deployment = new MongoDbEnterpriseDeployment()
-        1 * context.opsManagerFacade.deployReplicaSet(groupId, 'guid', port, mongodb_enterprise_health_check_user, mongodb_enterprise_health_check_password, mongodb_version) >> deployment
+        1 * context.opsManagerFacade.deployReplicaSet(groupId, 'guid', port, mongodb_enterprise_health_check_user, mongodb_enterprise_health_check_password, mongodb_version, feature_compatibility_version) >> deployment
 
         when:
         def result = MongoDbEnterpriseProvisionState.REQUEST_AUTOMATION_UPDATE.triggerAction(context)


### PR DESCRIPTION
This PR adds the update service functionality for MongoDB Enterprise.
It adds a new parameter 'featureCompatibilityVersion' which defines the feature compatibility version of MongoDB which was introduced with MongoDB 3.4.