### PR TITLE
Support BOSH uaa authentication

### DIFF
--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClientTest.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClientTest.groovy
@@ -41,7 +41,7 @@ class BoshRestClientTest extends BaseSpecification {
 
     def "get deployment"() {
         when:
-        def deployment = client.getDeployment("d-8tlihzux5s3nq370")
+        def deployment = client.getDeployment("shield")
         then:
         noExceptionThrown()
     }
@@ -55,7 +55,7 @@ class BoshRestClientTest extends BaseSpecification {
 
     def "get task"(){
         when:
-        def task = client.getTask("2857986")
+        def task = client.getTask("114794")
         then:
         noExceptionThrown()
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClient.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClient.groovy
@@ -38,16 +38,11 @@ class BoshRestClient {
     public static final String INFO = '/info'
     public static final String TASKS = '/tasks'
     public static final String DEPLOYMENTS = '/deployments'
-    public static final String VMS = '/vms'
     public static final String CLOUD_CONFIGS = '/cloud_configs'
     public static final String OAUTH_TOKEN = '/oauth/token'
 
     public static final String CONTENT_TYPE_YAML = "text/yaml"
     public static final String CLOUD_CONFIG_QUERY = "?limit=1"
-
-    private boolean checkedAuthType
-    private String token
-    private Calendar tokenExpirationTime
 
     private final BoshConfig boshConfig
     private final RestTemplateBuilder restTemplateBuilder
@@ -58,7 +53,7 @@ class BoshRestClient {
     }
 
     String fetchBoshInfo() {
-        createRestTemplate().getForEntity(prependBaseUrl(INFO),String.class).body
+        createRestTemplate().getForEntity(prependBaseUrl(INFO), String.class).body
     }
 
     String getDeployment(String id) {
@@ -67,7 +62,7 @@ class BoshRestClient {
     }
 
     private HttpHeaders createAuthHeaders() {
-        if (!checkedAuthType || (checkedAuthType && checkTokenIsExpired())) checkAuthTypeAndLogin()
+        String token = checkAuthTypeAndLogin()
         if (token != null) {
             return createBearerTokenAuthHeaders(token)
         } else {
@@ -75,38 +70,30 @@ class BoshRestClient {
         }
     }
 
-    @VisibleForTesting
-    private boolean checkTokenIsExpired() {
-        return tokenExpirationTime.before(Calendar.getInstance())
-    }
-
     @TypeChecked(TypeCheckingMode.SKIP)
-    protected void checkAuthTypeAndLogin() {
+    protected String checkAuthTypeAndLogin() {
         def jsonSlurper = new JsonSlurper()
         def info = jsonSlurper.parseText(fetchBoshInfo())
         if (info.user_authentication.type == "uaa") {
-            uaaLogin(info.user_authentication.options.url)
+            return uaaLogin(info.user_authentication.options.url)
         }
-        checkedAuthType = true
+        return null
     }
 
     @VisibleForTesting
     @TypeChecked(TypeCheckingMode.SKIP)
-    private void uaaLogin(String uaaBaseUrl) {
+    private String uaaLogin(String uaaBaseUrl) {
         def jsonSlurper = new JsonSlurper()
-        def authResponse = jsonSlurper.parseText(createRestTemplate().exchange(uaaBaseUrl + OAUTH_TOKEN + "?grant_type=client_credentials", HttpMethod.GET, new HttpEntity(createSimpleAuthHeaders(boshConfig.boshDirectorUsername, boshConfig.boshDirectorPassword)), String.class).body)
-        token = authResponse.access_token
-        tokenExpirationTime = Calendar.getInstance()
-        tokenExpirationTime.add(Calendar.SECOND, authResponse.expires_in - 5)
+        return jsonSlurper.parseText(createRestTemplate().exchange(uaaBaseUrl + OAUTH_TOKEN + "?grant_type=client_credentials", HttpMethod.GET, new HttpEntity(createSimpleAuthHeaders(boshConfig.boshDirectorUsername, boshConfig.boshDirectorPassword)), String.class).body).access_token
     }
 
     String postDeployment(String data) {
         log.trace("Posting new bosh deployment: \n${data}")
         HttpHeaders headers = createAuthHeaders()
-        headers.add('Content-Type',CONTENT_TYPE_YAML)
-        HttpEntity<String> request = new HttpEntity<>(data,headers)
+        headers.add('Content-Type', CONTENT_TYPE_YAML)
+        HttpEntity<String> request = new HttpEntity<>(data, headers)
 
-        def responseEntity = createRestTemplate().exchange(prependBaseUrl(DEPLOYMENTS),HttpMethod.POST,request,String.class)
+        def responseEntity = createRestTemplate().exchange(prependBaseUrl(DEPLOYMENTS), HttpMethod.POST, request, String.class)
 
         return handleRedirectonAndExtractTaskId(responseEntity)
     }
@@ -124,24 +111,24 @@ class BoshRestClient {
     }
 
     String deleteDeployment(String id) {
-        def response = createRestTemplate().exchange(prependBaseUrl(DEPLOYMENTS + '/' + id)+'?force=true',HttpMethod.DELETE,new HttpEntity<Object>(createAuthHeaders()),String.class)
+        def response = createRestTemplate().exchange(prependBaseUrl(DEPLOYMENTS + '/' + id) + '?force=true', HttpMethod.DELETE, new HttpEntity<Object>(createAuthHeaders()), String.class)
         return handleRedirectonAndExtractTaskId(response)
     }
 
     String fetchCloudConfig() {
-        createRestTemplate().exchange(prependBaseUrl(CLOUD_CONFIGS + CLOUD_CONFIG_QUERY),HttpMethod.GET,new HttpEntity<Object>(createAuthHeaders()),String.class).body
+        createRestTemplate().exchange(prependBaseUrl(CLOUD_CONFIGS + CLOUD_CONFIG_QUERY), HttpMethod.GET, new HttpEntity<Object>(createAuthHeaders()), String.class).body
     }
 
     void postCloudConfig(String data) {
         log.trace("Updating cloud config with: ${data}")
         HttpHeaders headers = createAuthHeaders()
-        headers.add('Content-Type',CONTENT_TYPE_YAML)
-        HttpEntity<String> request = new HttpEntity<>(data,headers)
-        createRestTemplate().exchange(prependBaseUrl(CLOUD_CONFIGS),HttpMethod.POST,request,Void.class)
+        headers.add('Content-Type', CONTENT_TYPE_YAML)
+        HttpEntity<String> request = new HttpEntity<>(data, headers)
+        createRestTemplate().exchange(prependBaseUrl(CLOUD_CONFIGS), HttpMethod.POST, request, Void.class)
     }
 
     String getTask(String id) {
-        createRestTemplate().exchange(prependBaseUrl(TASKS + '/' + id),HttpMethod.GET,new HttpEntity(createAuthHeaders()), String.class).body
+        createRestTemplate().exchange(prependBaseUrl(TASKS + '/' + id), HttpMethod.GET, new HttpEntity(createAuthHeaders()), String.class).body
     }
 
     @VisibleForTesting
@@ -163,7 +150,7 @@ class BoshRestClient {
         @Override
         void handleError(ClientHttpResponse response) throws IOException {
             // your error handling here
-            if(response.statusCode == HttpStatus.NOT_FOUND){
+            if (response.statusCode == HttpStatus.NOT_FOUND) {
                 throw new BoshResourceNotFoundException("Bosh resource not found, response body:${response.body?.toString()}", null, null, HttpStatus.NOT_FOUND)
             }
             super.handleError(response)

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/HttpHelper.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/HttpHelper.groovy
@@ -15,13 +15,15 @@
 
 package com.swisscom.cloud.sb.broker.util
 
+import groovy.util.logging.Slf4j
 import org.apache.commons.codec.binary.Base64
 import org.springframework.http.HttpHeaders
 
 import java.nio.charset.Charset
 
+@Slf4j
 class HttpHelper {
-    public static HttpHeaders createSimpleAuthHeaders(String username, String password ){
+    static HttpHeaders createSimpleAuthHeaders(String username, String password ){
         return new HttpHeaders(){
             {
                 set(HttpHeaders.AUTHORIZATION, computeBasicAuth(username,password) )
@@ -29,7 +31,16 @@ class HttpHelper {
         }
     }
 
-    public static String computeBasicAuth(String username,String password){
+    static HttpHeaders createBearerTokenAuthHeaders(String token ){
+        return new HttpHeaders(){
+            {
+                log.info("Bearer " + token)
+                set(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            }
+        }
+    }
+
+    static String computeBasicAuth(String username,String password){
         String auth = username + ":" + password
         byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(Charset.forName("US-ASCII")) )
         return "Basic " + new String( encodedAuth )

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/HttpHelper.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/HttpHelper.groovy
@@ -34,7 +34,7 @@ class HttpHelper {
     static HttpHeaders createBearerTokenAuthHeaders(String token ){
         return new HttpHeaders(){
             {
-                log.info("Bearer " + token)
+                log.trace("Bearer " + token)
                 set(HttpHeaders.AUTHORIZATION, "Bearer " + token)
             }
         }

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClientSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClientSpec.groovy
@@ -68,38 +68,21 @@ class BoshRestClientSpec extends Specification {
 
     def "Login to UAA"() {
         given:
-        def response = '''{"access_token": "eyJhbGciOiSldUIn0eyJqdGkiOiI0MGZhMmY4NjY5Y2E0YzNjY",
+        String expectedToken = "eyJhbGciOiSldUIn0eyJqdGkiOiI0MGZhMmY4NjY5Y2E0YzNjY"
+        def response = """{"access_token": "${expectedToken}",
                           "token_type": "bearer",
                           "expires_in": 41199,
                           "scope": "clients.read password.write clients.secret clients.write uaa.admin scim.write scim.read",
                           "jti": "fadfwe235wfdafawfewaf43fewf2"
-                        }'''
+                        }"""
         mockServer.expect(requestTo("https://localhost" + BoshRestClient.OAUTH_TOKEN + "?grant_type=client_credentials"))
                 .andExpect(method(HttpMethod.GET))
                 .andRespond(withSuccess(response, MediaType.APPLICATION_JSON))
         when:
-        boshRestClient.uaaLogin("https://localhost")
+        String responseToken = boshRestClient.uaaLogin("https://localhost")
         then:
         mockServer.verify()
-        !boshRestClient.checkTokenIsExpired()
-    }
-
-    def "Check expiration for UAA login is correct"() {
-        given:
-        def response = '''{"access_token": "eyJhbGciOiSldUIn0eyJqdGkiOiI0MGZhMmY4NjY5Y2E0YzNjY",
-                          "token_type": "bearer",
-                          "expires_in": 1,
-                          "scope": "clients.read password.write clients.secret clients.write uaa.admin scim.write scim.read",
-                          "jti": "fadfwe235wfdafawfewaf43fewf2"
-                        }'''
-        mockServer.expect(requestTo("https://localhost" + BoshRestClient.OAUTH_TOKEN + "?grant_type=client_credentials"))
-                .andExpect(method(HttpMethod.GET))
-                .andRespond(withSuccess(response, MediaType.APPLICATION_JSON))
-        when:
-        boshRestClient.uaaLogin("https://localhost")
-        then:
-        mockServer.verify()
-        boshRestClient.checkTokenIsExpired()
+        responseToken == expectedToken
     }
 
     def "GetDeployment"() {

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClientSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/client/BoshRestClientSpec.groovy
@@ -46,11 +46,11 @@ class BoshRestClientSpec extends Specification {
         restTemplateBuilder.build() >> restTemplate
 
         and:
-        boshRestClient = new BoshRestClient(new DummyConfig(boshDirectorBaseUrl: '',
+        boshRestClient = Spy(BoshRestClient, constructorArgs: [new DummyConfig(boshDirectorBaseUrl: '',
                 boshDirectorUsername: username,
-                boshDirectorPassword: password), restTemplateBuilder)
+                boshDirectorPassword: password), restTemplateBuilder])
+        boshRestClient.checkAuthTypeAndLogin() >> null
     }
-
 
     def "GetBoshInfo"() {
         given:
@@ -64,6 +64,42 @@ class BoshRestClientSpec extends Specification {
         then:
         mockServer.verify()
         result == response
+    }
+
+    def "Login to UAA"() {
+        given:
+        def response = '''{"access_token": "eyJhbGciOiSldUIn0eyJqdGkiOiI0MGZhMmY4NjY5Y2E0YzNjY",
+                          "token_type": "bearer",
+                          "expires_in": 41199,
+                          "scope": "clients.read password.write clients.secret clients.write uaa.admin scim.write scim.read",
+                          "jti": "fadfwe235wfdafawfewaf43fewf2"
+                        }'''
+        mockServer.expect(requestTo("https://localhost" + BoshRestClient.OAUTH_TOKEN + "?grant_type=client_credentials"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(response, MediaType.APPLICATION_JSON))
+        when:
+        boshRestClient.uaaLogin("https://localhost")
+        then:
+        mockServer.verify()
+        !boshRestClient.checkTokenIsExpired()
+    }
+
+    def "Check expiration for UAA login is correct"() {
+        given:
+        def response = '''{"access_token": "eyJhbGciOiSldUIn0eyJqdGkiOiI0MGZhMmY4NjY5Y2E0YzNjY",
+                          "token_type": "bearer",
+                          "expires_in": 1,
+                          "scope": "clients.read password.write clients.secret clients.write uaa.admin scim.write scim.read",
+                          "jti": "fadfwe235wfdafawfewaf43fewf2"
+                        }'''
+        mockServer.expect(requestTo("https://localhost" + BoshRestClient.OAUTH_TOKEN + "?grant_type=client_credentials"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(response, MediaType.APPLICATION_JSON))
+        when:
+        boshRestClient.uaaLogin("https://localhost")
+        then:
+        mockServer.verify()
+        boshRestClient.checkTokenIsExpired()
     }
 
     def "GetDeployment"() {


### PR DESCRIPTION
First call to BOSH API invokes a check for authentication method. If authentication method is `uaa` a token will be fetched and stored. Further calls will use the saved token unless it's expired.