### PR TITLE
Return actual OSB version for /version endpoint

### DIFF
--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        springBootVersion = '1.5.13.RELEASE'
+        springBootVersion = '1.5.14.RELEASE'
     }
     repositories {
         mavenCentral()
@@ -17,12 +17,12 @@ licenseReport {
 }
 
 ext['tomcat.version'] = '7.0.88'
-ext['flyway.version'] = '5.1.1'
+ext['flyway.version'] = '5.1.3'
 
 apply plugin: 'org.springframework.boot'
 
 processResources {
-    filesMatching("*.properties") {
+    filesMatching(["*.properties", "**/application-info.yml"]) {
         expand(project.properties)
     }
 }
@@ -53,7 +53,7 @@ dependencies {
     compile('org.springframework:spring-context-support')
     compile('org.codehaus.gpars:gpars:1.2.1')
     compile('joda-time:joda-time:2.10')
-    compile('org.flywaydb:flyway-core:5.1.1')
+    compile('org.flywaydb:flyway-core:5.1.3')
     compile('com.google.code.gson:gson:2.8.5')
     compile('org.apache.httpcomponents:httpclient:4.5.5')
     compile('commons-lang:commons-lang:2.6')

--- a/broker/src/main/resources/application-info.yml
+++ b/broker/src/main/resources/application-info.yml
@@ -1,0 +1,7 @@
+---
+spring:
+  profiles: info
+
+info:
+  core:
+    version: ${version}

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 spring:
-  profiles.active: default,extensions,secrets
+  profiles.active: info,default,extensions,secrets
 ---
 spring:
   profiles: default
@@ -41,8 +41,6 @@ management:
 #      client-secret:
 #      access-token-uri: https://uaa.service.cf.internal:8443/oauth/token
 
-
-
 endpoints:
   # accessibility of the endpoints is handled in ApplicationUserDetailsService class
   enabled: false
@@ -54,10 +52,6 @@ endpoints:
     enabled: true
   health:
     enabled: true
-
-info:
-  build:
-    version: ${version}
 
 server.tomcat.accesslog.enabled: true
 


### PR DESCRIPTION
`/version` endpoint returned `${version}` because application.yml was not expanded, due to some templates we are using, which should not be expanded.

The new application-info.yml can be extended with more custom information, given it is within the `info:` object.

Also update flyway and springboot dependencies on PATCH level.