### PR TITLE
Move RelationalDb functionality into a facade class

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BaseFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BaseFunctionalSpec.groovy
@@ -26,6 +26,7 @@ import org.joda.time.LocalTime
 import org.joda.time.Seconds
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.context.WebApplicationContext
@@ -100,5 +101,9 @@ abstract class BaseFunctionalSpec extends Specification {
                 Thread.sleep(sleepTime)
             }
         }
+    }
+
+    protected String readResourceContent(String resourcePath) {
+        return new File(getClass().getResource(resourcePath).getFile()).text
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProvider.groovy
@@ -27,6 +27,7 @@ import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import com.swisscom.cloud.sb.broker.model.UpdateRequest
 import com.swisscom.cloud.sb.broker.model.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.services.relationaldb.RelationalDbClient
+import com.swisscom.cloud.sb.broker.services.relationaldb.RelationalDbFacade
 import com.swisscom.cloud.sb.broker.services.relationaldb.RelationalDbServiceProvider
 import com.swisscom.cloud.sb.broker.updating.UpdateResponse
 import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailKey
@@ -47,8 +48,8 @@ class MariaDBServiceProvider extends RelationalDbServiceProvider implements Shie
     ServiceInstanceRepository serviceInstanceRepository
 
     @Autowired
-    MariaDBServiceProvider(MariaDBConfig dbConfig, MariaDBClientFactory dbClientFactory, ServiceInstanceRepository serviceInstanceRepository) {
-        super(dbConfig.default, dbClientFactory)
+    MariaDBServiceProvider(MariaDBConfig dbConfig, MariaDBClientFactory dbClientFactory, ServiceInstanceRepository serviceInstanceRepository, RelationalDbFacade relationalDbFacade) {
+        super(dbConfig.default, dbClientFactory, relationalDbFacade)
         this.mariaDBConfig = dbConfig
         this.serviceInstanceRepository = serviceInstanceRepository
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbFacade.groovy
@@ -1,0 +1,119 @@
+package com.swisscom.cloud.sb.broker.services.relationaldb
+
+import com.swisscom.cloud.sb.broker.binding.BindRequest
+import com.swisscom.cloud.sb.broker.binding.BindResponse
+import com.swisscom.cloud.sb.broker.binding.UnbindRequest
+import com.swisscom.cloud.sb.broker.error.ErrorCode
+import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
+import com.swisscom.cloud.sb.broker.model.ProvisionRequest
+import com.swisscom.cloud.sb.broker.model.ServiceDetail
+import com.swisscom.cloud.sb.broker.provisioning.DeprovisionResponse
+import com.swisscom.cloud.sb.broker.provisioning.ProvisionResponse
+import com.swisscom.cloud.sb.broker.util.StringGenerator
+import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailKey
+import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper
+import groovy.util.logging.Slf4j
+import org.springframework.stereotype.Component
+
+@Component
+@Slf4j
+class RelationalDbFacade {
+    public static final String MAX_CONNECTIONS = "max_connections"
+
+    ProvisionResponse provision(RelationalDbClient client, ProvisionRequest request, String databasePrefix = "CFDB_") {
+        String database = createDatabaseName(request.serviceInstanceGuid, databasePrefix)
+
+        if (client.databaseExists(database)) {
+            log.warn("Database ${database} already exists!")
+            ErrorCode.RELATIONAL_DB_ALREADY_EXISTS.throwNew()
+        }
+
+        client.createDatabase(database)
+
+        if (!client.databaseExists(database)) {
+            log.warn("Database ${database} not created!")
+            ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
+        }
+        new ProvisionResponse(details: ServiceDetailsHelper.create().add(ServiceDetailKey.DATABASE, database).getDetails())
+    }
+
+    DeprovisionResponse deprovision(RelationalDbClient client, DeprovisionRequest request) {
+        String database = ServiceDetailsHelper.from(request.serviceInstance.details).getValue(ServiceDetailKey.DATABASE)
+        if (!client.databaseExists(database)) {
+            log.info("Database ${database} already did not exist!")
+        } else {
+            client.dropDatabase(database)
+
+            if (client.databaseExists(database)) {
+                log.warn("Database ${database} could not be deleted!")
+                ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
+            }
+        }
+        new DeprovisionResponse(isAsync: false)
+    }
+
+    BindResponse bind(RelationalDbClient client, BindRequest request) {
+        String database = ServiceDetailsHelper.from(request.serviceInstance.details).getValue(ServiceDetailKey.DATABASE)
+        dbShouldExist(client, database)
+
+        String user = StringGenerator.randomAlphaNumericOfLength16()
+        userShouldNotExist(client, user)
+
+        String password = StringGenerator.randomAlphaNumericOfLength16()
+
+        log.info("About to create user:${user} and grant rights on database:${database}")
+        RelationalDbBindResponseDto credentials = client.createUserAndGrantRights(database, user, password, getMaxConnections(request))
+        if (!client.userExists(user)) {
+            log.warn("User ${user} could not be created!")
+            ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
+        }
+
+        Collection<ServiceDetail> details = ServiceDetailsHelper.create()
+                .add(ServiceDetailKey.USER, user)
+                .add(ServiceDetailKey.PASSWORD, password)
+                .getDetails()
+
+        return new BindResponse(details: details, credentials: credentials)
+    }
+
+    private int getMaxConnections(BindRequest request) {
+        def param = request.plan.parameters.find { it.name == MAX_CONNECTIONS }
+        return param ? (param.value as int) : 0
+    }
+
+    private void dbShouldExist(RelationalDbClient client, String database) {
+        boolean databaseExists = client.databaseExists(database)
+        if (!databaseExists) {
+            log.warn("Database ${database} not found!")
+            ErrorCode.RELATIONAL_DB_NOT_FOUND.throwNew()
+        }
+    }
+
+    private void userShouldNotExist(RelationalDbClient client, String user) {
+        boolean userExists = client.userExists(user)
+        if (userExists) {
+            log.warn("User ${user} already exists!")
+            ErrorCode.RELATIONAL_DB_USER_ALREADY_EXISTS.throwNew()
+        }
+    }
+
+    void unbind(RelationalDbClient client, UnbindRequest request) {
+        String database = ServiceDetailsHelper.from(request.serviceInstance.details).getValue(ServiceDetailKey.DATABASE)
+
+        String user = ServiceDetailsHelper.from(request.binding.details).getValue(ServiceDetailKey.USER)
+        if (!client.userExists(user)) {
+            log.warn("User ${user} does not exist!")
+        } else {
+            client.revokeRightsAndDropUser(database, user)
+            if (client.userExists(user)) {
+                log.warn("User ${user} could not be deleted!")
+                ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
+            }
+        }
+    }
+
+    static String createDatabaseName(String serviceInstanceId, String databasePrefix = "") {
+        String databaseName = databasePrefix + serviceInstanceId
+        databaseName.toUpperCase().replaceAll("-", "_")
+    }
+}

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbFacade.groovy
@@ -36,20 +36,20 @@ class RelationalDbFacade {
     public static final String MAX_CONNECTIONS = "max_connections"
 
     ProvisionResponse provision(RelationalDbClient client, ProvisionRequest request, String databasePrefix = "CFDB_") {
-        String database = createDatabaseName(request.serviceInstanceGuid, databasePrefix)
+        String databaseName = createDatabaseName(request.serviceInstanceGuid, databasePrefix)
 
-        if (client.databaseExists(database)) {
-            log.warn("Database ${database} already exists!")
+        if (client.databaseExists(databaseName)) {
+            log.warn("Database ${databaseName} already exists!")
             ErrorCode.RELATIONAL_DB_ALREADY_EXISTS.throwNew()
         }
 
-        client.createDatabase(database)
+        client.createDatabase(databaseName)
 
-        if (!client.databaseExists(database)) {
-            log.warn("Database ${database} not created!")
+        if (!client.databaseExists(databaseName)) {
+            log.warn("Database ${databaseName} not created!")
             ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
         }
-        new ProvisionResponse(details: ServiceDetailsHelper.create().add(ServiceDetailKey.DATABASE, database).getDetails())
+        new ProvisionResponse(details: ServiceDetailsHelper.create().add(ServiceDetailKey.DATABASE, databaseName).getDetails())
     }
 
     DeprovisionResponse deprovision(RelationalDbClient client, DeprovisionRequest request) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbFacade.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.swisscom.cloud.sb.broker.services.relationaldb
 
 import com.swisscom.cloud.sb.broker.binding.BindRequest

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbServiceProvider.groovy
@@ -18,138 +18,52 @@ package com.swisscom.cloud.sb.broker.services.relationaldb
 import com.swisscom.cloud.sb.broker.binding.BindRequest
 import com.swisscom.cloud.sb.broker.binding.BindResponse
 import com.swisscom.cloud.sb.broker.binding.UnbindRequest
-import com.swisscom.cloud.sb.broker.error.ErrorCode
 import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
 import com.swisscom.cloud.sb.broker.model.ProvisionRequest
-import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.provisioning.DeprovisionResponse
 import com.swisscom.cloud.sb.broker.provisioning.ProvisionResponse
 import com.swisscom.cloud.sb.broker.services.common.ServiceProvider
-import com.swisscom.cloud.sb.broker.util.StringGenerator
-import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailKey
-import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper
 import groovy.util.logging.Log4j
 
 @Log4j
 abstract class RelationalDbServiceProvider implements ServiceProvider {
-    public static final String MAX_CONNECTIONS = "max_connections"
     protected final RelationalDbClientFactory dbClientFactory
     protected final RelationalDbConfig dbConfig
+
+    RelationalDbFacade relationalDbFacade
 
     RelationalDbServiceProvider(RelationalDbConfig dbConfig, RelationalDbClientFactory dbClientFactory) {
         this.dbConfig = dbConfig
         this.dbClientFactory = dbClientFactory
+        this.relationalDbFacade = new RelationalDbFacade()
     }
 
     @Override
     ProvisionResponse provision(ProvisionRequest request) {
         RelationalDbClient client = buildDbClient(request.serviceInstanceGuid)
-        String database = createDatabaseName(request.serviceInstanceGuid)
-
-        if (client.databaseExists(database)) {
-            log.warn("Database ${database} already exists!")
-            ErrorCode.RELATIONAL_DB_ALREADY_EXISTS.throwNew()
-        }
-
-        client.createDatabase(database)
-
-        if (!client.databaseExists(database)) {
-            log.warn("Database ${database} not created!")
-            ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
-        }
-
-        return new ProvisionResponse(details: ServiceDetailsHelper.create().add(ServiceDetailKey.DATABASE, database).getDetails())
+        relationalDbFacade.provision(client, request)
     }
 
     @Override
     DeprovisionResponse deprovision(DeprovisionRequest request) {
-        String database = ServiceDetailsHelper.from(request.serviceInstance.details).getValue(ServiceDetailKey.DATABASE)
         RelationalDbClient client = buildDbClient(request.serviceInstanceGuid)
-        if (!client.databaseExists(database)) {
-            log.info("Database ${database} already did not exist!")
-        } else {
-            client.dropDatabase(database)
-
-            if (client.databaseExists(database)) {
-                log.warn("Database ${database} could not be deleted!")
-                ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
-            }
-        }
-        new DeprovisionResponse(isAsync: false)
+        relationalDbFacade.deprovision(client, request)
     }
 
     @Override
     BindResponse bind(BindRequest request) {
         RelationalDbClient client = buildDbClient(request.serviceInstance.guid)
-        String database = ServiceDetailsHelper.from(request.serviceInstance.details).getValue(ServiceDetailKey.DATABASE)
-        dbShouldExist(client, database)
-
-        String user = StringGenerator.randomAlphaNumericOfLength16()
-        userShouldNotExist(client, user)
-
-        String password = StringGenerator.randomAlphaNumericOfLength16()
-
-        log.info("About to create user:${user} and grant rights on database:${database}")
-        RelationalDbBindResponseDto credentials = client.createUserAndGrantRights(database, user, password, getMaxConnections(request))
-        if (!client.userExists(user)) {
-            log.warn("User ${user} could not be created!")
-            ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
-        }
-
-        Collection<ServiceDetail> details = ServiceDetailsHelper.create()
-                .add(ServiceDetailKey.USER, user)
-                .add(ServiceDetailKey.PASSWORD, password)
-                .getDetails()
-
-        return new BindResponse(details: details, credentials: credentials)
-    }
-
-    private int getMaxConnections(BindRequest request) {
-        def param = request.plan.parameters.find { it.name == MAX_CONNECTIONS }
-        return param ? (param.value as int) : 0
-    }
-
-    private void dbShouldExist(RelationalDbClient client, String database) {
-        boolean databaseExists = client.databaseExists(database)
-        if (!databaseExists) {
-            log.warn("Database ${database} not found!")
-            ErrorCode.RELATIONAL_DB_NOT_FOUND.throwNew()
-        }
-    }
-
-    private void userShouldNotExist(RelationalDbClient client, String user) {
-        boolean userExists = client.userExists(user)
-        if (userExists) {
-            log.warn("User ${user} already exists!")
-            ErrorCode.RELATIONAL_DB_USER_ALREADY_EXISTS.throwNew()
-        }
+        relationalDbFacade.bind(client, request)
     }
 
     @Override
     void unbind(UnbindRequest request) {
         RelationalDbClient client = buildDbClient(request.serviceInstance.guid)
-        String database = ServiceDetailsHelper.from(request.serviceInstance.details).getValue(ServiceDetailKey.DATABASE)
-
-        String user = ServiceDetailsHelper.from(request.binding.details).getValue(ServiceDetailKey.USER)
-        if (!client.userExists(user)) {
-            log.warn("User ${user} does not exist!")
-        } else {
-            client.revokeRightsAndDropUser(database, user)
-            if (client.userExists(user)) {
-                log.warn("User ${user} could not be deleted!")
-                ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew()
-            }
-        }
+        relationalDbFacade.unbind(client, request)
     }
 
     protected RelationalDbClient buildDbClient(String serviceInstanceGuid) {
         def port = dbConfig.port ? dbConfig.port.toInteger() : 0
         return dbClientFactory.build(dbConfig.host, port, dbConfig.adminUser, dbConfig.adminPassword)
-    }
-
-    protected String createDatabaseName(String serviceInstanceId) {
-        String databaseName = dbConfig.databasePrefix + serviceInstanceId;
-        databaseName = databaseName.toUpperCase().replaceAll("-", "_");
-        return databaseName
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbServiceProvider.groovy
@@ -32,10 +32,10 @@ abstract class RelationalDbServiceProvider implements ServiceProvider {
 
     RelationalDbFacade relationalDbFacade
 
-    RelationalDbServiceProvider(RelationalDbConfig dbConfig, RelationalDbClientFactory dbClientFactory) {
+    RelationalDbServiceProvider(RelationalDbConfig dbConfig, RelationalDbClientFactory dbClientFactory, RelationalDbFacade relationalDbFacade) {
         this.dbConfig = dbConfig
         this.dbClientFactory = dbClientFactory
-        this.relationalDbFacade = new RelationalDbFacade()
+        this.relationalDbFacade = relationalDbFacade
     }
 
     @Override

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProviderSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProviderSpec.groovy
@@ -23,13 +23,14 @@ import com.swisscom.cloud.sb.broker.model.*
 import com.swisscom.cloud.sb.broker.model.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.provisioning.ProvisionResponse
 import com.swisscom.cloud.sb.broker.services.relationaldb.RelationalDbBindResponseDto
-import com.swisscom.cloud.sb.broker.services.relationaldb.RelationalDbServiceProvider
+import com.swisscom.cloud.sb.broker.services.relationaldb.RelationalDbFacade
 import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailKey
 import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper
 import com.swisscom.cloud.sb.model.usage.ServiceUsageType
 import spock.lang.Specification
 
-import static com.swisscom.cloud.sb.broker.error.ErrorCode.*
+import static com.swisscom.cloud.sb.broker.error.ErrorCode.RELATIONAL_DB_NOT_FOUND
+import static com.swisscom.cloud.sb.broker.error.ErrorCode.RELATIONAL_DB_USER_ALREADY_EXISTS
 import static com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper.create
 import static com.swisscom.cloud.sb.broker.util.test.ErrorCodeHelper.assertServiceBrokerException
 
@@ -44,7 +45,7 @@ class MariaDBServiceProviderSpec extends Specification {
 
     private ServiceInstanceRepository serviceInstanceRepository
 
-    private String db_prefix = 'cf_'
+    private String db_prefix = 'cfdb_'
     private String db = (db_prefix + serviceInstanceGuid).toUpperCase()
 
     private ServiceInstance serviceInstance
@@ -111,7 +112,7 @@ class MariaDBServiceProviderSpec extends Specification {
     def "happy path: bind"() {
         given:
         BindRequest request = bindRequest()
-        request.plan.parameters = [new Parameter(name: RelationalDbServiceProvider.MAX_CONNECTIONS, value: '10')]
+        request.plan.parameters = [new Parameter(name: RelationalDbFacade.MAX_CONNECTIONS, value: '10')]
         mariaDBClient.databaseExists(db) >> true
         mariaDBClient.userExists(_) >>> [false, true]
         mariaDBClient.createUserAndGrantRights(db, _, _, _) >> new RelationalDbBindResponseDto()

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProviderSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProviderSpec.groovy
@@ -42,6 +42,7 @@ class MariaDBServiceProviderSpec extends Specification {
 
     MariaDBClient mariaDBClient
     MariaDBClientFactory mariaDBClientFactory
+    RelationalDbFacade relationalDbFacade
 
     private ServiceInstanceRepository serviceInstanceRepository
 
@@ -69,6 +70,7 @@ class MariaDBServiceProviderSpec extends Specification {
 
         mariaDBClient = Mock(MariaDBClient)
         mariaDBClientFactory = Mock(MariaDBClientFactory)
+        relationalDbFacade = new RelationalDbFacade()
         mariaDBClientFactory.build() >> mariaDBClient
         mariaDBClientFactory.build(_, _, _, _) >> mariaDBClient
         mariaDBServiceProvider = new MariaDBServiceProvider(
@@ -76,7 +78,8 @@ class MariaDBServiceProviderSpec extends Specification {
                         new MariaDBConnectionConfig(name: "default", databasePrefix: db_prefix, host: 'host', port: '1234', adminPassword: 'adminpw', adminUser: 'admin'),
                         new MariaDBConnectionConfig(name: "special", databasePrefix: db_prefix, host: 'special', port: '1234', adminPassword: 'special', adminUser: 'special')]),
                 mariaDBClientFactory,
-                serviceInstanceRepository)
+                serviceInstanceRepository,
+                relationalDbFacade)
     }
 
     def "happy path: provision"() {


### PR DESCRIPTION
For easier reuse of the RelationalDb the functionality is being moved to a facade class.