### PR TITLE
Improvement: common base model for requests

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/ProvisionRequest.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/ProvisionRequest.groovy
@@ -23,7 +23,7 @@ import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 
 @Entity
-class ProvisionRequest extends BaseModel {
+class ProvisionRequest extends BaseModel implements RequestWithParameters{
     @Column(unique = true)
     String serviceInstanceGuid
     @OneToOne()

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/RequestWithParameters.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/RequestWithParameters.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package com.swisscom.cloud.sb.broker.model
 
 interface RequestWithParameters {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/RequestWithParameters.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/RequestWithParameters.groovy
@@ -1,0 +1,7 @@
+package com.swisscom.cloud.sb.broker.model
+
+interface RequestWithParameters {
+    String serviceInstanceGuid
+    Plan plan
+    String parameters
+}

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/UpdateRequest.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/UpdateRequest.groovy
@@ -22,7 +22,7 @@ import javax.persistence.JoinColumn
 import javax.persistence.OneToOne
 
 @Entity
-class UpdateRequest extends BaseModel {
+class UpdateRequest extends BaseModel implements RequestWithParameters {
     String serviceInstanceGuid
     @OneToOne
     @JoinColumn(name = "plan_id")


### PR DESCRIPTION
This PR introduces a new interfaced that can be used during provisioning and updating a service instance. It is meant as a replacement for explicit usage of ProvisionRequest and UpdateRequest. Instead the new RequestWithParameters should be used.
This replacement should enable reuse of provision states during update service.