### PR TITLE
remove generic Kubernetes update state

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
@@ -131,10 +131,6 @@ abstract class AbstractKubernetesFacade<T extends AbstractKubernetesServiceConfi
         }
     }
 
-    @Override
-    boolean update(RequestWithParameters context){
-    }
-
     private HttpStatus getNamespaceStatusCode(String serviceInstanceGuid) {
         ResponseEntity namespaceResponse = kubernetesClient.exchange(
                 EndpointMapper.INSTANCE.getEndpointUrlByType('Namespace').getFirst() + '/' + serviceInstanceGuid,

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/KubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/KubernetesFacade.groovy
@@ -31,6 +31,4 @@ trait KubernetesFacade {
 
     abstract boolean isKubernetesNamespaceDeleted(String serviceInstanceGuid)
 
-    abstract boolean update(RequestWithParameters context)
-
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/service/state/KubernetesServiceProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/service/state/KubernetesServiceProvisionState.groovy
@@ -63,15 +63,6 @@ enum KubernetesServiceProvisionState implements ServiceStateWithAction<Kubernete
         }
     }),
 
-    KUBERNETES_UPDATE_SERVICE(LastOperation.Status.IN_PROGRESS, new OnStateChange<KubernetesServiceStateMachineContext>
-    () {
-        @Override
-        StateChangeActionResult triggerAction(KubernetesServiceStateMachineContext stateContext) {
-            return new StateChangeActionResult(
-                    go2NextState: stateContext.kubernetesFacade.update(getRequest(stateContext)))
-        }
-    }),
-
     KUBERNETES_SERVICE_PROVISION_SUCCESS(LastOperation.Status.SUCCESS, new NoOp()),
 
     KUBERNETES_SERVICE_PROVISION_FAILED(LastOperation.Status.FAILED, new NoOp())


### PR DESCRIPTION
this PR removes generic Kubernetes update state in favor of service specific states