### PR TITLE
Osb metrics to dedicated db

### DIFF
--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -28,6 +28,7 @@ management:
   metrics:
     export:
       influx:
+        enabled: false
         uri: http://localhost:8086
         step: 5s
         userName:

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -28,11 +28,10 @@ management:
   metrics:
     export:
       influx:
-        enabled: false
         uri: http://localhost:8086
         step: 5s
         userName:
-        db: influxdb
+        db: osb-metrics
         env: "local"
     enable:
       jvm: false


### PR DESCRIPTION
Change name of db in application.yml to name of dedicated osb metrics db as declared in the influxdb-ha-boshrelease jobs template.