### PR TITLE
Add platform context to UpdateRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Mongodb Enterprise - Delete default alerts on service creation
-
+- Adds context object to update request
+- Adapts Kubernetes Provisioning 
 
 
 ## [4.2.4] - 2018-09-06

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/util/ServiceLifeCycler.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/util/ServiceLifeCycler.groovy
@@ -427,10 +427,11 @@ class ServiceLifeCycler {
             final String serviceGuid,
             final String planGuid,
             Map<String, Object> parameters = null,
-            final Boolean async = false) {
+            final Boolean async = false,
+            Context context = null) {
 
         createServiceBrokerClientWithCustomErrorHandler()
-                .updateServiceInstance(new UpdateServiceInstanceRequest(serviceGuid, planGuid, parameters)
+                .updateServiceInstance(new UpdateServiceInstanceRequest(serviceGuid, planGuid, parameters, null, context)
                 .withAsyncAccepted(async)
                 .withServiceInstanceId(serviceInstanceId))
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
@@ -17,6 +17,7 @@ package com.swisscom.cloud.sb.broker.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.swisscom.cloud.sb.broker.cfapi.dto.UpdateDto
+import com.swisscom.cloud.sb.broker.context.ServiceContextPersistenceService
 import com.swisscom.cloud.sb.broker.error.ErrorCode
 import com.swisscom.cloud.sb.broker.model.Plan
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
@@ -43,6 +44,8 @@ class UpdatingController extends BaseController {
     private ServiceInstanceRepository serviceInstanceRepository
     private PlanRepository planRepository
     private UpdatingService updatingService
+    @Autowired
+    private ServiceContextPersistenceService serviceContextService
 
     @Autowired
     UpdatingController(ServiceInstanceRepository serviceInstanceRepository, PlanRepository planRepository, UpdatingService updatingService) {
@@ -90,7 +93,8 @@ class UpdatingController extends BaseController {
                 acceptsIncomplete: acceptsIncomplete,
                 plan: newPlan,
                 previousPlan: previousPlan,
-                parameters: serializeJson(updateDto.parameters))
+                parameters: serializeJson(updateDto.parameters),
+                serviceContext: serviceContextService.findOrCreate(updateDto.context))
     }
 
     private static String serializeJson(Map object) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/ProvisionRequest.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/ProvisionRequest.groovy
@@ -15,16 +15,12 @@
 
 package com.swisscom.cloud.sb.broker.model
 
-
 import javax.persistence.Entity
-import javax.persistence.OneToOne
 
 @Entity
 class ProvisionRequest extends RequestWithParameters {
 
     boolean acceptsIncomplete
-    @OneToOne
-    ServiceContext serviceContext
     String applicationUser
 
     @Override

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/RequestWithParameters.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/model/RequestWithParameters.groovy
@@ -30,4 +30,6 @@ abstract class RequestWithParameters extends BaseModel {
     @JsonIgnore
     Plan plan
     String parameters
+    @OneToOne
+    ServiceContext serviceContext
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacade.groovy
@@ -56,7 +56,7 @@ abstract class AbstractKubernetesFacade<T extends AbstractKubernetesServiceConfi
         this.kubernetesServiceConfig = abstractKubernetesServiceConfig
     }
 
-    protected abstract Map<String, String> getBindingMap(ProvisionRequest context)
+    protected abstract Map<String, String> getBindingMap(RequestWithParameters context)
 
     protected
     abstract Collection<ServiceDetail> buildServiceDetailsList(Map<String, String> bindingMap, List<ResponseEntity> responses)
@@ -76,7 +76,7 @@ abstract class AbstractKubernetesFacade<T extends AbstractKubernetesServiceConfi
         return buildServiceDetailsList(bindingMap, responses)
     }
 
-    protected Map<String, String> getServiceDetailBindingMap(ProvisionRequest request) {
+    protected Map<String, String> getServiceDetailBindingMap(RequestWithParameters request) {
         def context = ServiceContextHelper.convertFrom(request.serviceContext) as CloudFoundryContext
         [
                 (BaseTemplateConstants.SERVICE_ID.getValue()): request.getServiceInstanceGuid(),

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedis.groovy
@@ -17,9 +17,8 @@ package com.swisscom.cloud.sb.broker.services.kubernetes.facade.redis
 
 import com.swisscom.cloud.sb.broker.backup.SystemBackupProvider
 import com.swisscom.cloud.sb.broker.backup.shield.ShieldTarget
-import com.swisscom.cloud.sb.broker.backup.shield.dto.TaskDto
 import com.swisscom.cloud.sb.broker.cfextensions.extensions.Extension
-import com.swisscom.cloud.sb.broker.model.ProvisionRequest
+import com.swisscom.cloud.sb.broker.model.RequestWithParameters
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
@@ -50,7 +49,7 @@ class KubernetesFacadeRedis extends AbstractKubernetesFacade<KubernetesRedisConf
     }
 
     @Override
-    protected Map<String, String> getBindingMap(ProvisionRequest request) {
+    protected Map<String, String> getBindingMap(RequestWithParameters request) {
         def serviceDetailBindings = getServiceDetailBindingMap(request)
         def planBindings = getPlanParameterBindingMap(request.plan)
         def redisPassword = new StringGenerator().randomAlphaNumeric(30)
@@ -62,7 +61,7 @@ class KubernetesFacadeRedis extends AbstractKubernetesFacade<KubernetesRedisConf
                 (KubernetesRedisTemplateConstants.CONFIG_COMMAND.getValue()) : configCommand
         ]
         // Make copy of redisConfigurationDefaults Map for thread safety
-        (new HashMap<String,String>(kubernetesServiceConfig.redisConfigurationDefaults)) << planBindings << serviceDetailBindings << otherBindings
+        (new HashMap<String, String>(kubernetesServiceConfig.redisConfigurationDefaults)) << planBindings << serviceDetailBindings << otherBindings
     }
 
     @Override
@@ -110,7 +109,7 @@ class KubernetesFacadeRedis extends AbstractKubernetesFacade<KubernetesRedisConf
     }
 
     @Override
-    Collection<Extension> buildExtensions(){
+    Collection<Extension> buildExtensions() {
         return [new Extension(discovery_url: kubernetesServiceConfig.discoveryURL)]
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingPersistenceService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingPersistenceService.groovy
@@ -17,6 +17,7 @@ package com.swisscom.cloud.sb.broker.updating
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.swisscom.cloud.sb.broker.model.Plan
+import com.swisscom.cloud.sb.broker.model.ServiceContext
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import com.swisscom.cloud.sb.broker.model.UpdateRequest
@@ -54,9 +55,10 @@ class UpdatingPersistenceService {
         updateRequestRepository.saveAndFlush(updateRequest)
     }
 
-    void updatePlanAndServiceDetails(final ServiceInstance serviceInstance, final String updateParameters, final Collection<ServiceDetail> serviceDetails, Plan plan) {
+    void updatePlanAndServiceDetails(final ServiceInstance serviceInstance, final String updateParameters, final Collection<ServiceDetail> serviceDetails, Plan plan, ServiceContext serviceContext) {
         serviceInstance.plan = plan
         serviceInstance.parameters = mergeServiceInstanceParameter(serviceInstance.parameters, updateParameters)
+        serviceInstance.serviceContext = serviceContext
         serviceInstanceRepository.saveAndFlush(serviceInstance)
         updateServiceDetails(serviceDetails, serviceInstance)
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingService.groovy
@@ -41,7 +41,7 @@ class UpdatingService {
             handleAsyncClientRequirement(updateRequest.plan, acceptsIncomplete)
         updatingPersistenceService.saveUpdateRequest(updateRequest)
         def response = serviceProviderLookup.findServiceProvider(updateRequest.previousPlan).update(updateRequest)
-        updatingPersistenceService.updatePlanAndServiceDetails(serviceInstance, updateRequest.parameters, response.details, updateRequest.plan)
+        updatingPersistenceService.updatePlanAndServiceDetails(serviceInstance, updateRequest.parameters, response.details, updateRequest.plan, updateRequest.serviceContext)
         return response
     }
 

--- a/broker/src/main/resources/db/migration/V1_0_22__add_service_context_to_updateRequest.sql
+++ b/broker/src/main/resources/db/migration/V1_0_22__add_service_context_to_updateRequest.sql
@@ -1,0 +1,6 @@
+ALTER TABLE update_request
+  ADD COLUMN service_context_id BIGINT;
+
+ALTER TABLE update_request
+  ADD CONSTRAINT FK_update_request2service_context
+FOREIGN KEY (service_context_id) REFERENCES service_context (id);

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingControllerSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingControllerSpec.groovy
@@ -16,8 +16,10 @@
 package com.swisscom.cloud.sb.broker.controller
 
 import com.swisscom.cloud.sb.broker.cfapi.dto.UpdateDto
+import com.swisscom.cloud.sb.broker.context.ServiceContextPersistenceService
 import com.swisscom.cloud.sb.broker.error.ErrorCode
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
+import com.swisscom.cloud.sb.broker.model.ServiceContext
 import com.swisscom.cloud.sb.broker.model.repository.PlanRepository
 import com.swisscom.cloud.sb.broker.model.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.updating.UpdateResponse
@@ -28,11 +30,13 @@ class UpdatingControllerSpec extends Specification {
     private ServiceInstanceRepository serviceInstanceRepository
     private PlanRepository planRepository
     private UpdatingService updatingService
+    private ServiceContextPersistenceService serviceContextService
 
     def setup() {
         serviceInstanceRepository = Mock(ServiceInstanceRepository)
         planRepository = Mock(PlanRepository)
         updatingService = Mock(UpdatingService)
+        serviceContextService = Mock()
     }
 
     def "Throws Exception when ServiceInstance does not exist"() {
@@ -52,10 +56,12 @@ class UpdatingControllerSpec extends Specification {
 
     def "Doesn't throw Exception when ServiceInstance exists"() {
         def sut = new UpdatingController( serviceInstanceRepository, planRepository, updatingService)
+        sut.serviceContextService = serviceContextService
         def existingGuid = "DoesExist";
         def updateRequestDto = new UpdateDto()
         def acceptIncomplete = true;
 
+        serviceContextService.findOrCreate(updateRequestDto.context) >> new ServiceContext()
         serviceInstanceRepository.findByGuid(existingGuid) >> new ServiceInstance()
         updatingService.update(*_) >> new UpdateResponse()
 

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/AbstractKubernetesFacadeSpec.groovy
@@ -16,7 +16,7 @@
 package com.swisscom.cloud.sb.broker.services.kubernetes.facade
 
 import com.swisscom.cloud.sb.broker.model.DeprovisionRequest
-import com.swisscom.cloud.sb.broker.model.ProvisionRequest
+import com.swisscom.cloud.sb.broker.model.RequestWithParameters
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.services.kubernetes.client.rest.KubernetesClient
 import com.swisscom.cloud.sb.broker.services.kubernetes.config.AbstractKubernetesServiceConfig
@@ -49,7 +49,7 @@ class AbstractKubernetesFacadeSpec extends Specification {
         and:
         kubernetesFacade = new AbstractKubernetesFacade<AbstractKubernetesServiceConfig>(kubernetesClient, kubernetesConfig, kubernetesTemplateManager, endpointMapperParamsDecorated, kubernetesServiceConfig) {
             @Override
-            protected Map<String, String> getBindingMap(ProvisionRequest context) {
+            protected Map<String, String> getBindingMap(RequestWithParameters context) {
                 ["DUMMY_PLACEHOLDER": "dummy_value"]
             }
 


### PR DESCRIPTION
This feature adds a context object to the update request as it is present in the provision request.
This allows for context specific actions during update and it allows reuse of provision code sequences