### PR TITLE
Build a simple jar instead of a bootJar

### DIFF
--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -33,6 +33,14 @@ apply plugin: "idea"
 apply plugin: "org.springframework.boot"
 apply plugin: "io.spring.dependency-management"
 
+jar {
+    enabled = true
+}
+
+bootJar {
+    enabled = false
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
As described here https://github.com/spring-projects/spring-boot/issues/9242 build with bootJar can not be used as a dependency as we're doing it right now. For the way we're using the broker builds, I'd prefer to keep the smaller 1.4 MB jar instead of the big 80 MB bootJar.