### PR TITLE
Remove unnecessary quotes in bosh-manifest

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplate.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplate.groovy
@@ -20,8 +20,8 @@ import org.yaml.snakeyaml.Yaml
 import java.util.regex.Pattern
 
 class BoshTemplate {
-    public static final String REGEX_PLACEHOLDER_PREFIX = '\\{\\{'
-    public static final String REGEX_PLACEHOLDER_POSTFIX = '\\}\\}'
+    public static final String REGEX_PLACEHOLDER_PREFIX = '["]?\\{\\{'
+    public static final String REGEX_PLACEHOLDER_POSTFIX = '\\}\\}["]?'
     public static final Pattern anyPlaceHolder = createPattern('.*')
 
     private final String template

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplateSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplateSpec.groovy
@@ -47,7 +47,7 @@ class BoshTemplateSpec extends Specification {
                                 databases: {{databases}} #SERVICE-INSTANCE LEVEL
                                 instances: 3
                                 master-name: {{guid}} #SERVICE-INSTANCE LEVEL
-                                maxclients: {{maxclients}} #SERVICE-INSTANCE LEVEL
+                                maxclients: "{{maxclients}}" #SERVICE-INSTANCE LEVEL
                                 port: {{redis-server-port}} #SERVICE-INSTANCE LEVEL
                                 security:
                                   require_pass: {{password}} #SERVICE-TEMPLATE LEVEL
@@ -68,7 +68,10 @@ class BoshTemplateSpec extends Specification {
         template.replace('config-command', 'config-command')
         template.replace('slaveof-command', 'slaveof-command')
         and:
-        def expected = input.replace('{{', '').replace('}}', '')
+
+        def expected = input
+                .replace('"{{', '').replace('}}"', '')
+                .replace('{{', '').replace('}}', '')
 
 
         when:


### PR DESCRIPTION
**Problem**
When using more advanced features while deploying with bosh potential quotes can come in the way. Simple example, when trying to use variables:

Template:
```
mysql_admin_password: "{{mysql-admin-password}}"
```

Expected Result:
```
mysql_admin_password: ((mysql-admin-password))
```
This would replace with the "bosh variable" mysql-admin-password.

Actual Result:
```
mysql_admin_password: "((mysql-admin-password))"
```
This will not work as it will simply be interpreted as a string.

**Proposal**
Always get rid of quotes (if any) when replacing with values, this should be no problem as by default values are interpreted as strings.