### PR TITLE
Automate release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,3 +21,23 @@ jobs:
     - run: pushd docker && ./setup_docker.sh ; popd
     - run: ./gradlew clean build -x functionalTest
     - run: ./circleci-publish.sh
+
+  release:
+    docker:
+    - image: circleci/buildpack-deps
+
+    steps:
+    - checkout
+    - run: ./scripts/bump_and_create_release.sh
+
+workflows:
+  version: 2
+  build_and_release:
+    jobs:
+      - build
+      - release:
+          requires:
+            - build
+          filters:
+            branches:
+              only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,17 @@ jobs:
 
 workflows:
   version: 2
-  build_and_release:
+  build:
+    jobs:
+      - build
+
+  build_and_release_nightly:
+    triggers:
+      - schedule:
+          cron: "0 1 * * *"
+          filters:
+            branches:
+              only: develop
     jobs:
       - build
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     - run: 'if [[ -z "${CIRCLE_PULL_REQUEST}" ]]; then openssl aes-256-cbc -md md5 -pass pass:$ENCRYPTION_PASSWORD -in secring.gpg.enc -out local.secring.gpg -d; fi'
     - run: pushd docker && ./setup_docker.sh ; popd
     - run: ./gradlew clean build -x functionalTest
-    - run: ./circleci-publish.sh
+    - run: ./scripts/circleci-publish.sh
 
   release:
     docker:

--- a/circleci-publish.sh
+++ b/circleci-publish.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [[ -z ${CIRCLE_PULL_REQUEST} ]] && [ ${CIRCLE_BRANCH} = 'develop' ]; then
-  ./gradlew uploadArchives -x functionalTest -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}"
-elif [[ -z ${CIRCLE_PULL_REQUEST} ]] && [ ${CIRCLE_BRANCH} = 'master' ]; then
-  ./gradlew uploadArchives closeAndReleaseRepository -x functionalTest -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" -PsigningKeyId="${SIGNING_KEY_ID}" -PsigningPassword="${SIGNING_PASSWORD}" -PsigningSecretKeyRingFile="$(pwd)/local.secring.gpg"
-fi

--- a/scripts/bump_and_create_release.sh
+++ b/scripts/bump_and_create_release.sh
@@ -12,12 +12,16 @@ if [ -z "$GITHUB_PASSWORD" ]; then
     exit 1
 fi
 
-echo "default login ${GITHUB_USERNAME} password ${GITHUB_PASSWORD}" > ${HOME}/.netrc
+if [ -z "$INCREASE" ]; then
+    INCREASE="dynamic"
+fi
+
+echo "default login ${GITHUB_USER} password ${GITHUB_PASSWORD}" > ${HOME}/.netrc
 # trace shell
 set -x
 
-git config --global user.email "cicd@concourse.ci"
-git config --global user.name "${GITHUB_USERNAME}"
+git config --global user.email "swisscom-ci@github.com"
+git config --global user.name "${GITHUB_USER}"
 
 export WORKING_DIR=${PWD}
 export VERSION=$(awk -F'=' '/^version\=/ { print $2 }' gradle.properties)
@@ -25,7 +29,8 @@ export VERSION_ARR=( ${VERSION//./ } )
 
 # Checks CHANGELOG.md for type of release (major, minor or patch)
 if [ "${INCREASE}" == "dynamic" ]; then
-CHANGELOGS=$(cat $(pwd)/CHANGELOG.md | awk '{print toupper($0)}' | sed -n '/^## \[UNRELEASED\]/,/^## \[/p' | sed '1d;$d;/^$/d')
+    CHANGELOGS=$(cat $(pwd)/CHANGELOG.md | awk '{print toupper($0)}' | sed -n '/^## \[UNRELEASED\]/,/^## \[/p' | sed '1d;$d;/^$/d')
+    echo $CHANGELOGS
     if echo "$CHANGELOGS" | egrep -q "^\- \[MAJOR\] "; then
         INCREASE="major"
     elif echo "$CHANGELOGS" | egrep -q "^\- \[MINOR\] "; then

--- a/scripts/bump_and_create_release.sh
+++ b/scripts/bump_and_create_release.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# fail on error
+set -e
+
+if [ -z "$GITHUB_USER" ]; then
+    echo "ERROR: Environment variable GITHUB_USER is not set"
+    exit 1
+fi
+
+if [ -z "$GITHUB_PASSWORD" ]; then
+    echo "ERROR: Environment variable GITHUB_PASSWORD is not set"
+    exit 1
+fi
+
+echo "default login ${GITHUB_USERNAME} password ${GITHUB_PASSWORD}" > ${HOME}/.netrc
+# trace shell
+set -x
+
+git config --global user.email "cicd@concourse.ci"
+git config --global user.name "${GITHUB_USERNAME}"
+
+export WORKING_DIR=${PWD}
+export VERSION=$(awk -F'=' '/^version\=/ { print $2 }' gradle.properties)
+export VERSION_ARR=( ${VERSION//./ } )
+
+# Checks CHANGELOG.md for type of release (major, minor or patch)
+if [ "${INCREASE}" == "dynamic" ]; then
+CHANGELOGS=$(cat $(pwd)/CHANGELOG.md | awk '{print toupper($0)}' | sed -n '/^## \[UNRELEASED\]/,/^## \[/p' | sed '1d;$d;/^$/d')
+    if echo "$CHANGELOGS" | egrep -q "^\- \[MAJOR\] "; then
+        INCREASE="major"
+    elif echo "$CHANGELOGS" | egrep -q "^\- \[MINOR\] "; then
+        INCREASE="minor"
+    elif [ $(echo "$CHANGELOGS" | sed '/^\s*$/d' | wc -l) -gt 0 ]; then
+        INCREASE="patch"
+    else
+        echo "No changelogs in Unreleased, please add changelogs before releasing"
+        exit 0
+    fi
+fi
+
+VERSION_ARR[2]=$(echo ${VERSION_ARR[2]} | awk -F'-' '{print $1}')
+if [ "${INCREASE}" == "major" ]; then
+    ((VERSION_ARR[0]+=1))
+    VERSION_ARR[1]=0
+    VERSION_ARR[2]=0
+elif [ "${INCREASE}" == "minor" ]; then
+    ((VERSION_ARR[1]+=1))
+    VERSION_ARR[2]=0
+fi
+
+RELEASE_VERSION="${VERSION_ARR[0]}.${VERSION_ARR[1]}.${VERSION_ARR[2]}"
+
+((VERSION_ARR[2]+=1))
+NEXT_DEV_VERSION="${VERSION_ARR[0]}.${VERSION_ARR[1]}.${VERSION_ARR[2]}-SNAPSHOT"
+
+./scripts/release.sh ${RELEASE_VERSION} ${NEXT_DEV_VERSION}

--- a/scripts/circleci-publish.sh
+++ b/scripts/circleci-publish.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ -z ${CIRCLE_PULL_REQUEST} ]] && [ ${CIRCLE_BRANCH} = 'develop' ]; then
+  ../gradlew uploadArchives -x functionalTest -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}"
+elif [[ -z ${CIRCLE_PULL_REQUEST} ]] && [ ${CIRCLE_BRANCH} = 'master' ]; then
+  ../gradlew uploadArchives closeAndReleaseRepository -x functionalTest -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" -PsigningKeyId="${SIGNING_KEY_ID}" -PsigningPassword="${SIGNING_PASSWORD}" -PsigningSecretKeyRingFile="$(pwd)/local.secring.gpg"
+fi

--- a/travis-publish.sh
+++ b/travis-publish.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'develop' ]; then
-  ./gradlew uploadArchives -x functionalTest -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}"
-elif [ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master' ]; then
-  ./gradlew uploadArchives closeAndReleaseRepository -x functionalTest -PossrhUsername="${SONATYPE_USERNAME}" -PossrhPassword="${SONATYPE_PASSWORD}" -PsigningKeyId="${SIGNING_KEY_ID}" -PsigningPassword="${SIGNING_PASSWORD}" -PsigningSecretKeyRingFile="$(pwd)/local.secring.gpg"
-fi


### PR DESCRIPTION
Every night at 1:00 CircleCI will start the `build_and_release_nigthly` workflow, which will, based on the content in `CHANGELOG.md` in the develop branch, bump the version and release to master.

**How to use it:**
So you can set the following in the `CHANGELOG.md` to trigger a new release:
line starting with `- [MAJOR]` to bump a major release
line starting with `- [MINOR]` to bump a minor release
any other content will bump a patch release

As long as the there is no content in the `Unreleased` section, there will be no action taken.

**Example CHANGELOG.md:**
```
[Unreleased]
- [MAJOR] This will trigger the script to bump a major version, e.g. 2.4.2 to 3.0.0
- [MINOR] In absence of MAJOR this will bump a minor version, e.g. 2.4.2 to 2.5.0
- In absence of MAJOR or MINOR this will bump a patch version, e.g. 2.4.2 to 2.4.3
```