### PR TITLE
omit null values for MariaDBShieldTarget

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBShieldTarget.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBShieldTarget.groovy
@@ -16,7 +16,7 @@
 package com.swisscom.cloud.sb.broker.services.mariadb
 
 import com.swisscom.cloud.sb.broker.backup.shield.ShieldTarget
-import groovy.json.JsonBuilder
+import groovy.json.JsonGenerator
 
 /*
  Example:
@@ -47,12 +47,13 @@ class MariaDBShieldTarget implements ShieldTarget {
 
     @Override
     String endpointJson() {
-        new JsonBuilder(mysql_user: user,
-                mysql_password: password,
-                mysql_host: host,
-                mysql_port: port,
-                mysql_database: database,
-                mysql_options: MYSQL_OPTIONS,
-                mysql_bindir: bindir)
+        new JsonGenerator.Options().excludeNulls().build().toJson(
+                [mysql_user    : user,
+                 mysql_password: password,
+                 mysql_host    : host,
+                 mysql_port    : port,
+                 mysql_database: database,
+                 mysql_options : MYSQL_OPTIONS,
+                 mysql_bindir  : bindir])
     }
 }

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBShieldTargetSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBShieldTargetSpec.groovy
@@ -20,7 +20,7 @@ import spock.lang.Specification
 
 
 class MariaDBShieldTargetSpec extends Specification {
-    def "generates an endpoint json for mysql"() {
+    def "generates an endpoint json without optional bindir for mysql"() {
         given:
         def target = new MariaDBShieldTarget(
                 user: 'user1',
@@ -28,15 +28,22 @@ class MariaDBShieldTargetSpec extends Specification {
                 host: 'host1',
                 database: 'db1')
         and:
-        String expected = """{
-                            "mysql_user": "user1",
-                            "mysql_password": "pw1",
-                            "mysql_host": "host1",
-                            "mysql_database": "db1",
-                            "mysql_options": "${MariaDBShieldTarget.MYSQL_OPTIONS}"
-                        }"""
+        String expected = """{"mysql_user": "user1","mysql_password": "pw1","mysql_host": "host1","mysql_database": "db1","mysql_options": "${MariaDBShieldTarget.MYSQL_OPTIONS}"}"""
         expect:
-        JSONAssert.assertEquals(expected, target.endpointJson(), false)
+        JSONAssert.assertEquals(expected, target.endpointJson(), true)
     }
 
+    def "generates an endpoint json for mysql"() {
+        given:
+        def target = new MariaDBShieldTarget(
+                user: 'user1',
+                password: 'pw1',
+                host: 'host1',
+                database: 'db1',
+                bindir: '/var/lib/mysql/bin')
+        and:
+        String expected = """{"mysql_user": "user1","mysql_password": "pw1","mysql_host": "host1","mysql_database": "db1","mysql_options": "${MariaDBShieldTarget.MYSQL_OPTIONS}","mysql_bindir": "/var/lib/mysql/bin"}"""
+        expect:
+        JSONAssert.assertEquals(expected, target.endpointJson(), true)
+    }
 }


### PR DESCRIPTION
Shield does not ignore null values and will therefore fail if null values are not omitted.