### PR TITLE
Add Static Audit class with specific format

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/Audit.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/Audit.groovy
@@ -17,15 +17,20 @@ package com.swisscom.cloud.sb.broker.util
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.swisscom.cloud.sb.broker.error.ErrorCode
+import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
 @Slf4j
+@CompileStatic
 class Audit {
-    static log(String message, Map parameters = null) {
+    static log(String message) {
+        log(message, null)
+    }
+
+    static log(String message, Map parameters) {
         if (parameters != null) {
             message += " (${stringifyParameters(parameters)}"
         }
-
         ensureLog(message)
     }
 
@@ -33,7 +38,7 @@ class Audit {
         ArrayList<String> kvpList = new ArrayList<String>()
         def objectMapper = new ObjectMapper()
 
-        parameters.each { k,v -> kvpList.add("$k:${objectMapper.writeValueAsString(v)}")}
+        parameters.each { k,v -> kvpList.add("$k:${objectMapper.writeValueAsString(v)}".toString())}
 
         String.join(",", kvpList)
     }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/Audit.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/Audit.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.swisscom.cloud.sb.broker.util
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.swisscom.cloud.sb.broker.error.ErrorCode
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class Audit {
+    static log(String message, Map parameters = null) {
+        if (parameters != null) {
+            message += " (${stringifyParameters(parameters)}"
+        }
+
+        ensureLog(message)
+    }
+
+    static String stringifyParameters(Map parameters) {
+        ArrayList<String> kvpList = new ArrayList<String>()
+        def objectMapper = new ObjectMapper()
+
+        parameters.each { k,v -> kvpList.add("$k:${objectMapper.writeValueAsString(v)}")}
+
+        String.join(",", kvpList)
+    }
+
+    private static void ensureLog(String message) {
+        String formattedString = "[!Audit]${message}[/!Audit]"
+
+        if (log.infoEnabled)
+            log.info(formattedString)
+        else if (log.warnEnabled)
+            log.warn(formattedString)
+        else
+            ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("AuditLogging not possible. Log Level must have Warn or Info")
+    }
+}

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/util/AuditSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/util/AuditSpec.groovy
@@ -20,6 +20,25 @@ import spock.lang.Specification
 
 class AuditSpec extends Specification {
 
+    def "Log with message and parameters"() {
+        when:
+        String message = "This is a test"
+
+        then:
+        null == Audit.log(message)
+        noExceptionThrown()
+    }
+
+    def "Log with simple message"() {
+        when:
+        String message = "This is a test"
+        def parameters = [key: "value", obj: [well: [well: 'well']]]
+
+        then:
+        null == Audit.log(message, parameters)
+        noExceptionThrown()
+    }
+
     def 'Can serialize Parameters correctly'() {
         given:
         def parameters = [key: "value", obj: [well: [well: 'well']]]

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/util/AuditSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/util/AuditSpec.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.swisscom.cloud.sb.broker.util
+
+import spock.lang.Specification
+
+
+class AuditSpec extends Specification {
+
+    def 'Can serialize Parameters correctly'() {
+        given:
+        def parameters = [key: "value", obj: [well: [well: 'well']]]
+
+        when:
+        String json = Audit.stringifyParameters(parameters)
+
+        then:
+        json == 'key:"value",obj:{"well":{"well":"well"}}'
+    }
+}


### PR DESCRIPTION
Logs messages can then be extracted via GREP/REGEX to forward redirect to a audit location.