### PR TITLE
Add support for proxy in RestTemplateBuilder

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/RestTemplateBuilder.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/RestTemplateBuilder.groovy
@@ -30,6 +30,7 @@ import org.apache.http.impl.auth.BasicScheme
 import org.apache.http.impl.client.BasicAuthCache
 import org.apache.http.impl.client.BasicCredentialsProvider
 import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.impl.client.ProxyAuthenticationStrategy
 import org.apache.http.protocol.BasicHttpContext
 import org.apache.http.protocol.HttpContext
 import org.apache.http.ssl.SSLContexts
@@ -135,6 +136,20 @@ class RestTemplateBuilder {
 
     RestTemplateBuilder withClientSideCertificate(String cert, String key) {
         keyStore = createKeyStore(cert, key)
+        this
+    }
+
+    RestTemplateBuilder withProxy(String proxyHost, String proxyPort, String proxyProtocol) {
+        httpClientBuilder.setProxy(new HttpHost(proxyHost, Integer.parseInt(proxyPort), proxyProtocol))
+        this
+    }
+
+    RestTemplateBuilder withAuthenticatedProxy(String proxyHost, String proxyPort, String proxyProtocol, String proxyUser, String proxyPassword) {
+        withProxy(proxyHost, proxyPort, proxyProtocol)
+        CredentialsProvider credsProvider = new BasicCredentialsProvider()
+        credsProvider.setCredentials(new AuthScope(proxyHost, Integer.parseInt(proxyPort)), new UsernamePasswordCredentials(proxyUser, proxyPassword))
+        httpClientBuilder.setDefaultCredentialsProvider(credsProvider)
+        httpClientBuilder.setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
         this
     }
 


### PR DESCRIPTION
Currently it is not possible to use RestTemplateBuilder when proxy is required. This commit adds support for both authenticated and unauthenticated proxy and is based on http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/impl/client/HttpClientBuilder.html