### PR TITLE
Add Bearer Authorization for RestTemplateBuilder

### DIFF
--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/util/RestTemplateBuilderTest.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/util/RestTemplateBuilderTest.groovy
@@ -70,6 +70,19 @@ class RestTemplateBuilderTest extends Specification {
         httpServer?.stop()
     }
 
+    def "restTemplate with Bearer Token"() {
+        given:
+        String token = 'AbCdEf123456'
+        HttpServerApp httpServer = new HttpServerApp().startServer(HttpServerConfig.create(http_port).withBearerAuthentication(token))
+        when:
+        def response = makeGetRequest(new RestTemplateBuilder().withBearerAuthentication(token).build())
+        then:
+        response.statusCode == HttpStatus.OK
+        response.body.equalsIgnoreCase('hello')
+        cleanup:
+        httpServer?.stop()
+    }
+
     def 'GET request over https to self signed certificate endpoint throws exception'() {
         given:
         HttpServerApp httpServer = new HttpServerApp().startServer(HttpServerConfig.create(http_port).withHttpsPort(https_port)

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/test/httpserver/HttpServerConfig.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/test/httpserver/HttpServerConfig.groovy
@@ -27,10 +27,11 @@ class HttpServerConfig {
     private String keyStoreAlias
     private String trustStorePath
     private String trustStorePassword
+    private String bearerToken
 
 
     static enum AuthenticationType {
-        NONE, SIMPLE, DIGEST, MUTUAL
+        NONE, SIMPLE, DIGEST, BEARER, MUTUAL
     }
 
     private HttpServerConfig(int httpPort) { this.httpPort = httpPort }
@@ -70,6 +71,12 @@ class HttpServerConfig {
         this.authenticationType = authenticationType.MUTUAL
         this.trustStorePath = trustStorePath
         this.trustStorePassword = trustStorePassword
+        return this
+    }
+
+    HttpServerConfig withBearerAuthentication(String token) {
+        this.authenticationType = authenticationType.BEARER
+        this.bearerToken = token
         return this
     }
 


### PR DESCRIPTION
This commit adds authorization via Bearer token for the
RestTemplateBuilder. The additional method will add an "Authorization"
HTTP header to any request via interceptors.