### PR TITLE
set the serviceinstanceguid as log context

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/AbstractBackupJob.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/AbstractBackupJob.groovy
@@ -17,8 +17,10 @@ package com.swisscom.cloud.sb.broker.backup.job
 
 import com.swisscom.cloud.sb.broker.model.Backup
 import groovy.transform.CompileStatic
+import groovy.util.logging.Slf4j
 
 @CompileStatic
+@Slf4j
 abstract class AbstractBackupJob extends AbstractBackupRestoreJob<Backup> {
 
     @Override
@@ -36,5 +38,15 @@ abstract class AbstractBackupJob extends AbstractBackupRestoreJob<Backup> {
     @Override
     protected Backup getTargetEntity(String id) {
         return backupPersistenceService.findBackupByGuid(id)
+    }
+
+    @Override
+    protected String getServiceInstanceGuid(String id) {
+        try {
+            return getTargetEntity(id).serviceInstanceGuid
+        } catch (NullPointerException e) {
+            log.error("Could not get backup for backup guid " + id)
+            return null
+        }
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/AbstractBackupRestoreJob.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/AbstractBackupRestoreJob.groovy
@@ -41,7 +41,7 @@ abstract class AbstractBackupRestoreJob<T> extends AbstractJob {
     @Override
     void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         String id = getJobId(jobExecutionContext)
-        MDC.put("serviceInstanceGuid", id)
+        MDC.put("serviceInstanceGuid", getServiceInstanceGuid(id))
         log.info("Executing job with class:${this.class.getSimpleName()} with id:${id}")
         T targetEntity = null
         try {
@@ -49,6 +49,7 @@ abstract class AbstractBackupRestoreJob<T> extends AbstractJob {
             if (targetEntity == null) {
                 throw new RuntimeException("Could not load object of type:${T.class.simpleName} with ID:${id}")
             }
+
             Backup.Status status = handleJob(targetEntity)
             if (status == Backup.Status.SUCCESS) {
                 handleSucess(targetEntity, id)
@@ -85,6 +86,8 @@ abstract class AbstractBackupRestoreJob<T> extends AbstractJob {
     abstract protected Backup.Status handleJob(T t)
 
     abstract protected <T> T getTargetEntity(String id)
+
+    abstract protected String getServiceInstanceGuid(String id)
 
     protected BackupRestoreProvider findBackupProvider(Backup backup) {
         backupRestoreProviderLookup.findBackupProvider(backup.plan)

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/AbstractBackupRestoreJob.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/AbstractBackupRestoreJob.groovy
@@ -41,7 +41,7 @@ abstract class AbstractBackupRestoreJob<T> extends AbstractJob {
     @Override
     void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         String id = getJobId(jobExecutionContext)
-        MDC.put("serviceInstanceGuid", getServiceInstanceGuid(id))
+        MDC.put("serviceInstanceGuid", getServiceInstanceGuid(id)?:"unknown")
         log.info("Executing job with class:${this.class.getSimpleName()} with id:${id}")
         T targetEntity = null
         try {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/RestoreJob.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/backup/job/RestoreJob.groovy
@@ -53,4 +53,14 @@ class RestoreJob extends AbstractBackupRestoreJob<Restore> {
     protected Restore getTargetEntity(String id) {
         return backupPersistenceService.findRestoreByGuid(id)
     }
+
+    @Override
+    protected String getServiceInstanceGuid(String id) {
+        try {
+            return getTargetEntity(id).backup.serviceInstanceGuid
+        } catch (NullPointerException e) {
+            log.error("Could not get backup for restore guid " + id)
+            return null
+        }
+    }
 }


### PR DESCRIPTION
The job id for backup and restore jobs is not the service instance guid. With this fix, the correct log context is being set with MDC.