### PR TITLE
Add dashboardUrl for RelationalDbServiceProvider

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/relationaldb/RelationalDbConfig.groovy
@@ -26,4 +26,5 @@ class RelationalDbConfig implements Config {
     String adminUser
     String adminPassword
     String databasePrefix
+    String dashboardPath
 }

--- a/broker/src/main/resources/application.yml
+++ b/broker/src/main/resources/application.yml
@@ -100,6 +100,7 @@ com.swisscom.cloud.sb.broker.service.mariadb:
     shieldAgentUrl: 'shield-agent:5444'
     discoveryURL: "http://localhost:8080/v2/api-docs"
     bindir: '/var/vcap/packages/shield-mysql/bin'
+    dashboardPath:
 
 com.swisscom.cloud.sb.broker.shield:
   baseUrl: 'http://localhost:8082'


### PR DESCRIPTION
MariaDB ServiceProvider now supports dashboardUrl in provision response if `dashboardPath` per cluster is not empty.