### PR TITLE
ParentServiceProvider to handle parent service providers

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/ParentServiceFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/ParentServiceFunctionalSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.swisscom.cloud.sb.broker.functional
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.swisscom.cloud.sb.broker.error.ErrorCode
+import com.swisscom.cloud.sb.broker.error.ServiceBrokerException
+import com.swisscom.cloud.sb.broker.model.repository.ServiceContextDetailRepository
+import com.swisscom.cloud.sb.broker.model.repository.ServiceInstanceRepository
+import com.swisscom.cloud.sb.broker.services.common.ServiceProviderLookup
+import com.swisscom.cloud.sb.broker.util.servicecontext.ServiceContextHelper
+import com.swisscom.cloud.sb.broker.util.test.DummyServiceProvider
+import com.swisscom.cloud.sb.broker.util.test.ParentDummyServiceProvider
+import com.swisscom.cloud.sb.client.model.DeleteServiceInstanceRequest
+import com.swisscom.cloud.sb.client.model.LastOperationState
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cloud.servicebroker.model.CloudFoundryContext
+import org.springframework.cloud.servicebroker.model.KubernetesContext
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.HttpClientErrorException
+import spock.lang.Shared
+
+class ParentServiceFunctionalSpec extends BaseFunctionalSpec {
+    @Autowired
+    private ServiceInstanceRepository serviceInstanceRepository
+    @Autowired
+    private ServiceContextDetailRepository contextRepository
+
+    private int processDelayInSeconds = DummyServiceProvider.RETRY_INTERVAL_IN_SECONDS * 2
+
+    @Shared
+    private String parentServiceInstanceGuid
+
+    @Shared
+    private String childServiceInstanceGuid
+
+    def setup() {
+        serviceLifeCycler.createServiceIfDoesNotExist('ParentDummy', ServiceProviderLookup.findInternalName(ParentDummyServiceProvider.class))
+    }
+
+    def cleanupSpec() {
+        serviceLifeCycler.cleanup()
+    }
+
+    def "provision async service instance with parent reference"() {
+        given:
+        serviceLifeCycler.setServiceInstanceId(UUID.randomUUID().toString())
+        serviceLifeCycler.setServiceBindingId(UUID.randomUUID().toString())
+        serviceLifeCycler.createServiceInstanceAndAssert(ParentDummyServiceProvider.RETRY_INTERVAL_IN_SECONDS * 2, true, true,
+                ['delay': String.valueOf(processDelayInSeconds)])
+        this.parentServiceInstanceGuid = serviceLifeCycler.serviceInstanceId
+
+        when:
+        serviceLifeCycler.setServiceInstanceId(UUID.randomUUID().toString())
+        serviceLifeCycler.createServiceInstanceAndAssert(DummyServiceProvider.RETRY_INTERVAL_IN_SECONDS * 2, true, true,
+                ['delay': String.valueOf(processDelayInSeconds), 'parent_reference': this.parentServiceInstanceGuid])
+        this.childServiceInstanceGuid = serviceLifeCycler.serviceInstanceId
+        then:
+        serviceLifeCycler.getServiceInstanceStatus().state == LastOperationState.SUCCEEDED
+
+        def si = serviceInstanceRepository.findByGuid(serviceLifeCycler.serviceInstanceId)
+        assert si != null
+        assert si.parentServiceInstance != null
+    }
+
+    def "provision async service instance with non-existing parent reference"() {
+        given:
+        serviceLifeCycler.setServiceInstanceId(UUID.randomUUID().toString())
+        serviceLifeCycler.setServiceBindingId(UUID.randomUUID().toString())
+
+        when:
+        serviceLifeCycler.createServiceInstanceAndAssert(DummyServiceProvider.RETRY_INTERVAL_IN_SECONDS * 4, true, true,
+                ['delay': String.valueOf(processDelayInSeconds), 'parent_reference': 'service-instance-xxx'])
+
+        then:
+        def ex = thrown(HttpClientErrorException)
+        ex.statusCode == HttpStatus.NOT_FOUND
+        ex.responseBodyAsString != null
+        def serviceBrokerException = new ObjectMapper().readValue(ex.responseBodyAsString, ServiceBrokerException)
+        serviceBrokerException.code == ErrorCode.PARENT_SERVICE_INSTANCE_NOT_FOUND.code
+    }
+
+    def "deprovision async parent service instance with active children"() {
+        when:
+        serviceBrokerClient.deleteServiceInstance(new DeleteServiceInstanceRequest(parentServiceInstanceGuid, serviceLifeCycler.cfService.guid, serviceLifeCycler.cfService.plans[0].guid, true))
+
+        then:
+        def ex = thrown(HttpClientErrorException)
+        ex.statusCode == HttpStatus.BAD_REQUEST
+    }
+
+    def "deprovision async parent service instance with deleted children"() {
+        when:
+        serviceBrokerClient.deleteServiceInstance(new DeleteServiceInstanceRequest(childServiceInstanceGuid, serviceLifeCycler.cfService.guid, serviceLifeCycler.cfService.plans[0].guid, true))
+        serviceLifeCycler.waitUntilMaxTimeOrTargetState(ParentDummyServiceProvider.RETRY_INTERVAL_IN_SECONDS * 3, childServiceInstanceGuid)
+        serviceBrokerClient.deleteServiceInstance(new DeleteServiceInstanceRequest(parentServiceInstanceGuid, serviceLifeCycler.cfService.guid, serviceLifeCycler.cfService.plans[0].guid, true))
+        serviceLifeCycler.setServiceInstanceId(parentServiceInstanceGuid)
+        serviceLifeCycler.waitUntilMaxTimeOrTargetState(ParentDummyServiceProvider.RETRY_INTERVAL_IN_SECONDS * 3, parentServiceInstanceGuid)
+        then:
+        serviceLifeCycler.getServiceInstanceStatus().state == LastOperationState.SUCCEEDED
+    }
+
+    void assertCloudFoundryContext(String serviceInstanceGuid, String org_guid = "org_id", String space_guid = "space_id") {
+        def serviceInstance = serviceInstanceRepository.findByGuid(serviceInstanceGuid)
+        assert serviceInstance != null
+        assert serviceInstance.serviceContext != null
+        assert serviceInstance.serviceContext.platform == CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM
+        assert serviceInstance.serviceContext.details.find { it -> it.key == ServiceContextHelper.CF_ORGANIZATION_GUID }.value == org_guid
+        assert serviceInstance.serviceContext.details.find { it -> it.key == ServiceContextHelper.CF_SPACE_GUID }.value == space_guid
+    }
+
+    void assertKubernetesContext(String serviceInstanceGuid) {
+        def serviceInstance = serviceInstanceRepository.findByGuid(serviceInstanceGuid)
+        assert serviceInstance != null
+        assert serviceInstance.serviceContext != null
+        assert serviceInstance.serviceContext.platform == KubernetesContext.KUBERNETES_PLATFORM
+        assert serviceInstance.serviceContext.details.find { it -> it.key == ServiceContextHelper.KUBERNETES_NAMESPACE }.value == "namespace_guid"
+    }
+
+}
+

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningController.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningController.groovy
@@ -38,7 +38,6 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
-import org.apache.commons.lang.StringUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.servicebroker.model.CloudFoundryContext
 import org.springframework.http.HttpStatus
@@ -53,8 +52,6 @@ import java.security.Principal
 @CompileStatic
 @Slf4j
 class ProvisioningController extends BaseController {
-    public static final String PARAM_ACCEPTS_INCOMPLETE = 'accepts_incomplete'
-
     @Autowired
     private ProvisioningService provisioningService
     @Autowired
@@ -98,10 +95,6 @@ class ProvisioningController extends BaseController {
             }
 
             def request = createProvisionRequest(serviceInstanceGuid, provisioningDto, acceptsIncomplete, principal)
-            if (StringUtils.contains(request.parameters, "parent_reference") &&
-                    !provisioningPersistenceService.findParentServiceInstance(request.parameters)) {
-                ErrorCode.PARENT_SERVICE_INSTANCE_NOT_FOUND.throwNew()
-            }
 
             ProvisionResponse provisionResponse = provisioningService.provision(request)
 

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/error/ErrorCode.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/error/ErrorCode.groovy
@@ -93,7 +93,10 @@ enum ErrorCode {
     SERVICE_NOT_BINDABLE("69069", "Service not bindable", "SC-SB-SERVICE-NOT-BINDABLE", HttpStatus.CONFLICT),
     SERVICE_NOT_ACTIVE("69070", "Service not active", "SC-SC-SERVICE-NOT-ACTIVE", HttpStatus.CONFLICT),
     PLAN_NOT_ACTIVE("69071", "Plan not active", "SC-SC-PLAN-NOT-ACTIVE", HttpStatus.CONFLICT),
-    BACKUP_GONE("69072", "Backup has been deleted", "SC-SB-BKUP-GONE", HttpStatus.GONE)
+    BACKUP_GONE("69072", "Backup has been deleted", "SC-SB-BKUP-GONE", HttpStatus.GONE),
+    CHILDREN_SERVICE_INSTANCES_ACTIVE("69073", "Parent has active children service instances", "SC-SB-ACTIVE-CHILDREN-SI", HttpStatus.BAD_REQUEST),
+    NOT_A_PARENT_PROVIDER("69074", "Given parent is not a parent service instance", "SC-SB-NOT-PARENT-SI", HttpStatus.BAD_REQUEST),
+    PARENT_SERVICE_FULL("69075", "Given parent is full", "SC-SB-FULL-PARENT-SI", HttpStatus.BAD_REQUEST)
 
     final String code
     final String errorCode

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
@@ -101,10 +101,11 @@ class ProvisioningService {
         if (!provisioningPersistenceService.findParentServiceInstance(provisionRequest.parameters)) {
             ErrorCode.PARENT_SERVICE_INSTANCE_NOT_FOUND.throwNew()
         } else {
-            ServiceProvider parentServiceProvider = serviceProviderLookup.findServiceProvider(provisioningPersistenceService.findParentServiceInstance(provisionRequest.parameters).plan.guid)
-            if (!parentServiceProvider instanceof ParentServiceProvider) {
+            ServiceInstance parentServiceInstance = provisioningPersistenceService.findParentServiceInstance(provisionRequest.parameters)
+            ServiceProvider parentServiceProvider = serviceProviderLookup.findServiceProvider(parentServiceInstance.plan.guid)
+            if (!(parentServiceProvider instanceof ParentServiceProvider)) {
                 ErrorCode.NOT_A_PARENT_PROVIDER.throwNew()
-            } else if (parentServiceProvider instanceof ParentServiceProvider && parentServiceProvider.isFull()) {
+            } else if (parentServiceProvider instanceof ParentServiceProvider && parentServiceProvider.isFull(parentServiceInstance)) {
                 ErrorCode.PARENT_SERVICE_FULL.throwNew()
             }
         }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningService.groovy
@@ -86,9 +86,7 @@ class ProvisioningService {
         handleAsyncClientRequirement(deprovisionRequest.serviceInstance.plan, deprovisionRequest.acceptsIncomplete)
 
         ServiceProvider serviceProvider = serviceProviderLookup.findServiceProvider(deprovisionRequest.serviceInstance.plan)
-        if (serviceProvider instanceof ParentServiceProvider && serviceProvider.hasActiveChildren()) {
-            ErrorCode.CHILDREN_SERVICE_INSTANCES_ACTIVE.throwNew()
-        }
+        checkActiveChildren(deprovisionRequest)
 
         DeprovisionResponse response = serviceProvider.deprovision(deprovisionRequest)
         if (!response.isAsync) {
@@ -108,6 +106,13 @@ class ProvisioningService {
             } else if (parentServiceProvider instanceof ParentServiceProvider && parentServiceProvider.isFull(parentServiceInstance)) {
                 ErrorCode.PARENT_SERVICE_FULL.throwNew()
             }
+        }
+    }
+
+    private void checkActiveChildren(DeprovisionRequest deprovisionRequest) {
+        ServiceProvider serviceProvider = serviceProviderLookup.findServiceProvider(deprovisionRequest.serviceInstance.plan)
+        if (serviceProvider instanceof ParentServiceProvider && serviceProvider.hasActiveChildren(deprovisionRequest.serviceInstance)) {
+            ErrorCode.CHILDREN_SERVICE_INSTANCES_ACTIVE.throwNew()
         }
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
@@ -15,7 +15,7 @@ trait ParentServiceProvider {
         if (param == null) {
             return false
         } else {
-            return (param.value as int) >= serviceInstance.childs.count({ !it.deleted })
+            return (param.value as int) <= serviceInstance.childs.count({ !it.deleted })
         }
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
@@ -1,0 +1,16 @@
+package com.swisscom.cloud.sb.broker.util
+
+import com.swisscom.cloud.sb.broker.model.ServiceInstance
+
+trait ParentServiceProvider {
+    private static final String MAX_CHILDREN = "max_children"
+
+    boolean hasActiveChildren(ServiceInstance serviceInstance) {
+        return serviceInstance.childs.any({!it.deleted})
+    }
+
+    boolean isFull(ServiceInstance serviceInstance) {
+        def param = serviceInstance.plan.parameters.find { it.name == MAX_CHILDREN }
+        return (param.value as int) >= serviceInstance.childs.count({!it.deleted})
+    }
+}

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
@@ -1,16 +1,21 @@
 package com.swisscom.cloud.sb.broker.util
 
+import com.swisscom.cloud.sb.broker.model.Parameter
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 
 trait ParentServiceProvider {
     private static final String MAX_CHILDREN = "max_children"
 
     boolean hasActiveChildren(ServiceInstance serviceInstance) {
-        return serviceInstance.childs.any({!it.deleted})
+        return serviceInstance.childs.any({ !it.deleted })
     }
 
     boolean isFull(ServiceInstance serviceInstance) {
-        def param = serviceInstance.plan.parameters.find { it.name == MAX_CHILDREN }
-        return (param.value as int) >= serviceInstance.childs.count({!it.deleted})
+        Parameter param = serviceInstance.plan.parameters.find { it.name == MAX_CHILDREN }
+        if (param == null) {
+            return false
+        } else {
+            return (param.value as int) >= serviceInstance.childs.count({ !it.deleted })
+        }
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/ParentDummyServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/ParentDummyServiceProvider.groovy
@@ -1,0 +1,8 @@
+package com.swisscom.cloud.sb.broker.util.test
+
+import com.swisscom.cloud.sb.broker.util.ParentServiceProvider
+import org.springframework.stereotype.Component
+
+@Component
+class ParentDummyServiceProvider extends DummyServiceProvider implements ParentServiceProvider {
+}


### PR DESCRIPTION
**Problem:**
Services provided in a parent / child relationship have to bring their own logic to manage the given restrictions. This leads to a lot of duplicated code, as the problems are bound to be very similar.

**Proposal:**
The trait ParentServiceProvider will provide the default logic, which is automatically applied when the ServiceProvider `implements ParentServiceProvider`. The default logic can be overridden by every ServiceProvider.

**Limitations:**
In the plan for the parent serviceprovider the parameter `max_children` has to be set (default is unlimited).