### PR TITLE
insert protocolVersion in automationConfig for mongodb 4.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- insert protocolVersion for new opsmanager version 4.0
 
 
 ## [5.3.3] - 2019-01-18

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/automation/ReplicaSetDto.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/automation/ReplicaSetDto.groovy
@@ -18,6 +18,7 @@ package com.swisscom.cloud.sb.broker.services.mongodb.enterprise.dto.automation
 
 class ReplicaSetDto implements Serializable {
     String _id
+    String protocolVersion
     List<Member> members
 
     static class Member implements Serializable {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -218,7 +218,7 @@ class OpsManagerFacade {
         if (automationConfig.replicaSets && automationConfig.replicaSets.size() > 0) {
             throw new IllegalStateException("ReplicaSets should be empty")
         }
-        automationConfig.replicaSets = [new ReplicaSetDto(_id: replicaSetId, members: members)]
+        automationConfig.replicaSets = [new ReplicaSetDto(_id: replicaSetId, members: members, protocolVersion: "1")]
 
         def deployment = new MongoDbEnterpriseDeployment(database: replicaSetId, replicaSet: replicaSetId, hostPorts: hostPorts,
                 monitoringAgentUser: USER_NAME_MMS_MONITORING_AGENT,


### PR DESCRIPTION
In order to use mongodb version 4.0.x, protocolVersion must be set in the automation config.