### PR TITLE
handle generic configs for bosh based services in statemachine

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshBasedServiceConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshBasedServiceConfig.groovy
@@ -22,4 +22,5 @@ trait BoshBasedServiceConfig implements EndpointConfig, BoshConfig {
     String portRange
     String boshManifestFolder
     boolean shuffleAzs
+    List<Map<String, String>> boshConfigs
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -91,7 +91,7 @@ class BoshFacade {
 
     void handleTemplatingAndCreateConfigs(ProvisionRequest provisionRequest, BoshTemplateCustomizer templateCustomizer) {
         for (config in serviceConfig.boshConfigs) {
-            BoshTemplate template = boshTemplateFactory.build(templateConfig.getTemplateForServiceKey(config.get('templateIdentifier')).first())
+            BoshTemplate template = boshTemplateFactory.build(templateConfig.getTemplateForServiceKey(config.get('templateName')).first())
             template.replace(PARAM_GUID, provisionRequest.serviceInstanceGuid)
             templateCustomizer.customizeBoshConfigTemplate(template, config.get('type'), provisionRequest)
             createBoshClient().setConfig(new BoshConfigRequestDto(name: provisionRequest.serviceInstanceGuid, type: config.get('type'), content: template.build()))

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -89,6 +89,15 @@ class BoshFacade {
         return serviceDetails
     }
 
+    void handleTemplatingAndCreateConfigs(ProvisionRequest provisionRequest, BoshTemplateCustomizer templateCustomizer) {
+        for (config in serviceConfig.boshConfigs) {
+            BoshTemplate template = boshTemplateFactory.build(templateConfig.getTemplateForServiceKey(config.get('templateIdentifier')).first())
+            template.replace(PARAM_GUID, provisionRequest.serviceInstanceGuid)
+            templateCustomizer.customizeBoshConfigTemplate(template, config.get('type'), provisionRequest)
+            createBoshClient().setConfig(new BoshConfigRequestDto(name: provisionRequest.serviceInstanceGuid, type: config.get('type'), content: template.build()))
+        }
+    }
+
     @VisibleForTesting
     private List<String> generateHostNames(String guid, int hostCount) {
         (List<String>) (0..<hostCount).inject([]) {
@@ -145,6 +154,10 @@ class BoshFacade {
 
     private static String findBoshDeploymentId(LastOperationJobContext context) {
         return ServiceDetailsHelper.from(context.serviceInstance.details).findValue(BoshServiceDetailKey.BOSH_DEPLOYMENT_ID).or(generateDeploymentId(context.serviceInstance.guid))
+    }
+
+    void deleteConfigsIfExists(LastOperationJobContext lastOperationJobContext) {
+        deleteConfig(lastOperationJobContext.serviceInstance.guid, null)
     }
 
     Optional<String> deleteBoshDeploymentIfExists(LastOperationJobContext lastOperationJobContext) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplateCustomizer.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplateCustomizer.groovy
@@ -21,4 +21,5 @@ import com.swisscom.cloud.sb.broker.model.ServiceDetail
 
 interface BoshTemplateCustomizer {
     Collection<ServiceDetail> customizeBoshTemplate(BoshTemplate template, ProvisionRequest provisionRequest)
+    void customizeBoshConfigTemplate(BoshTemplate template, String type, ProvisionRequest provisionRequest)
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/statemachine/BoshDeprovisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/statemachine/BoshDeprovisionState.groovy
@@ -26,6 +26,13 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 enum BoshDeprovisionState implements ServiceStateWithAction<BoshStateMachineContext> {
+    DELETE_CONFIGS(LastOperation.Status.IN_PROGRESS,new OnStateChange<BoshStateMachineContext>() {
+        @Override
+        StateChangeActionResult triggerAction(BoshStateMachineContext context) {
+            context.boshFacade.deleteConfigsIfExists(context.lastOperationJobContext)
+            return new StateChangeActionResult(go2NextState: true)
+        }
+    }),
     DELETE_BOSH_DEPLOYMENT(LastOperation.Status.IN_PROGRESS,new OnStateChange<BoshStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(BoshStateMachineContext context) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/statemachine/BoshProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/statemachine/BoshProvisionState.groovy
@@ -26,6 +26,13 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 enum BoshProvisionState implements ServiceStateWithAction<BoshStateMachineContext> {
+    CREATE_CONFIGS(LastOperation.Status.IN_PROGRESS, new OnStateChange<BoshStateMachineContext>() {
+        @Override
+        StateChangeActionResult triggerAction(BoshStateMachineContext context) {
+            context.boshFacade.handleTemplatingAndCreateConfigs(context.lastOperationJobContext.provisionRequest, context.boshTemplateCustomizer)
+            new StateChangeActionResult(go2NextState: true)
+        }
+    }),
     CREATE_DEPLOYMENT(LastOperation.Status.IN_PROGRESS, new OnStateChange<BoshStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(BoshStateMachineContext context) {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/statemachine/BoshStateMachineFactory.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/statemachine/BoshStateMachineFactory.groovy
@@ -23,12 +23,14 @@ import groovy.transform.TypeChecked
 @TypeChecked
 class BoshStateMachineFactory {
     static StateMachine createProvisioningStateFlow() {
-        new StateMachine([BoshProvisionState.CREATE_DEPLOYMENT,
+        new StateMachine([BoshProvisionState.CREATE_CONFIGS,
+                          BoshProvisionState.CREATE_DEPLOYMENT,
                           BoshProvisionState.CHECK_BOSH_DEPLOYMENT_TASK_STATE])
     }
 
     static StateMachine createDeprovisioningStateFlow() {
-        new StateMachine([BoshDeprovisionState.DELETE_BOSH_DEPLOYMENT,
+        new StateMachine([BoshDeprovisionState.DELETE_CONFIGS,
+                          BoshDeprovisionState.DELETE_BOSH_DEPLOYMENT,
                           BoshDeprovisionState.CHECK_BOSH_UNDEPLOY_TASK_STATE])
     }
 }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProvider.groovy
@@ -110,6 +110,9 @@ class MongoDbEnterpriseServiceProvider
         return [from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_TARGET_AGENT_COUNT, template.instanceCount() as String)]
     }
 
+    @Override
+    void customizeBoshConfigTemplate(BoshTemplate template, String type, ProvisionRequest provisionRequest) {}
+
     @VisibleForTesting
     private String getMongoDbBinaryPath() {
         ((MongoDbEnterpriseConfig) serviceConfig).libFolder + '/bin/'

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeSpec.groovy
@@ -43,8 +43,9 @@ class BoshFacadeSpec extends Specification {
         boshClientFactory.build(*_) >> boshClient
         and:
         TemplateConfig.ServiceTemplate st = new TemplateConfig.ServiceTemplate(name: "test", version: "1.0.0", templates: [new File('src/test/resources/bosh/template_mongodbent_v5.yml').text])
-        serviceConfig = new DummyConfig(retryIntervalInSeconds: 1, maxRetryDurationInMinutes: 1)
-        templateConfig = new TemplateConfig(serviceTemplates: [st])
+        TemplateConfig.ServiceTemplate configST = new TemplateConfig.ServiceTemplate(name: "test-config", version: "1.0.0", templates: [new File('src/test/resources/bosh/cloud_config_template_mongodbent_v5.yml').text])
+        serviceConfig = new DummyConfig(retryIntervalInSeconds: 1, maxRetryDurationInMinutes: 1, boshConfigs: [['templateIdentifier': 'test-config', 'type': 'cloud']])
+        templateConfig = new TemplateConfig(serviceTemplates: [st, configST])
         and:
         boshTemplate = Mock(BoshTemplate)
         boshTemplateFactory = Mock(BoshTemplateFactory) { build(_) >> boshTemplate }
@@ -106,6 +107,22 @@ class BoshFacadeSpec extends Specification {
         1 * boshTemplate.replace('name1', 'value1')
         1 * boshTemplate.shuffleAzs()
         result.size() == 3
+    }
+
+    def "templating generic config from config is handled correctly"() {
+        given:
+        def request = new ProvisionRequest(serviceInstanceGuid: "guid", plan: new Plan(templateUniqueIdentifier: 'test',
+                parameters: [new Parameter(name: 'name1', value: 'value1')]))
+        def customizer = Mock(BoshTemplateCustomizer)
+        and:
+        1 * customizer.customizeBoshConfigTemplate(boshTemplate, 'cloud', request) >> null
+        and:
+        1 * boshClient.setConfig(_) >> null
+        when:
+        boshFacade.handleTemplatingAndCreateConfigs(request, customizer)
+        then:
+        1 * boshTemplate.replace('guid', request.serviceInstanceGuid)
+        noExceptionThrown()
     }
 
     def "bosh Deploy task state checking is handled correctly for normal cases"() {

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacadeSpec.groovy
@@ -44,7 +44,7 @@ class BoshFacadeSpec extends Specification {
         and:
         TemplateConfig.ServiceTemplate st = new TemplateConfig.ServiceTemplate(name: "test", version: "1.0.0", templates: [new File('src/test/resources/bosh/template_mongodbent_v5.yml').text])
         TemplateConfig.ServiceTemplate configST = new TemplateConfig.ServiceTemplate(name: "test-config", version: "1.0.0", templates: [new File('src/test/resources/bosh/cloud_config_template_mongodbent_v5.yml').text])
-        serviceConfig = new DummyConfig(retryIntervalInSeconds: 1, maxRetryDurationInMinutes: 1, boshConfigs: [['templateIdentifier': 'test-config', 'type': 'cloud']])
+        serviceConfig = new DummyConfig(retryIntervalInSeconds: 1, maxRetryDurationInMinutes: 1, boshConfigs: [['templateName': 'test-config', 'type': 'cloud']])
         templateConfig = new TemplateConfig(serviceTemplates: [st, configST])
         and:
         boshTemplate = Mock(BoshTemplate)

--- a/broker/src/test/resources/bosh/cloud_config_template_mongodbent_v5.yml
+++ b/broker/src/test/resources/bosh/cloud_config_template_mongodbent_v5.yml
@@ -1,0 +1,24 @@
+networks:
+  - name: {{guid}}
+    subnets:
+      - azs: [{{azs}}]
+        cloud_properties:
+          name: {{networkName}}
+        dns:
+          - {{dns}}
+        gateway: {{gatewayIp}}
+        range: {{networkCidr}}
+        reserved: [{{reserved}}]
+        static: []
+    type: manual
+vm_types:
+  - cloud_properties:
+      cpu: {{cpu}}
+      ram: {{ram}}
+      disk: {{ephemeralDiskSize}}
+      nsxt:
+        ns_groups: [{{nsGroup}}]
+    name: {{guid}}
+disk_types:
+  - disk_size: {{persistentDiskSize}}
+    name: {{guid}}


### PR DESCRIPTION
Generic configs for bosh based services will be handled similar to the deployment template. To use any generic configs, simply define in the service config. Example:

```
com.swisscom.cloud.sb.broker.service.mongodbent:
  boshConfigs:
  - templateName: <name of template in serviceTemplates>
    type: <config type, e.g. cloud>
```
If none are set, there will also no generic config be set.

**Breaking change**
With this change services that implement `BoshTemplateCustomizer` have to implement the method following method, regardless if they are using generic configs:
`void customizeBoshConfigTemplate(BoshTemplate template, String type, ProvisionRequest provisionRequest)`