### PR TITLE
Bugfix/failed serviceinstances still count as active children

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
@@ -26,10 +26,10 @@ trait ParentServiceProvider {
     }
 
     int getActiveChildrenCount(ServiceInstance serviceInstance) {
-        List<ServiceInstance> undeletedChildren = serviceInstance.childs.findAll { si -> !si.deleted }
+        def undeletedChildren = serviceInstance.childs.findAll { si -> !si.deleted }
         int completedUndeletedChildrenCount = undeletedChildren.count { si -> si.completed }
 
-        List<ServiceInstance> uncompletedChildren = undeletedChildren.findAll { si -> !si.completed }
+        def uncompletedChildren = undeletedChildren.findAll { si -> !si.completed }
 
         int childrenProvisionInProgress = 0
         uncompletedChildren.each {

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
@@ -1,13 +1,19 @@
 package com.swisscom.cloud.sb.broker.util
 
+import com.swisscom.cloud.sb.broker.model.LastOperation
 import com.swisscom.cloud.sb.broker.model.Parameter
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
+import com.swisscom.cloud.sb.broker.model.repository.LastOperationRepository
+import org.springframework.beans.factory.annotation.Autowired
 
 trait ParentServiceProvider {
     private static final String MAX_CHILDREN = "max_children"
 
+    @Autowired(required = true)
+    LastOperationRepository lastOperationRepository
+
     boolean hasActiveChildren(ServiceInstance serviceInstance) {
-        return serviceInstance.childs.any({ !it.deleted })
+        return getActiveChildrenCount(serviceInstance) > 0
     }
 
     boolean isFull(ServiceInstance serviceInstance) {
@@ -15,7 +21,25 @@ trait ParentServiceProvider {
         if (param == null) {
             return false
         } else {
-            return (param.value as int) <= serviceInstance.childs.count({ !it.deleted })
+            return (param.value as int) <= getActiveChildrenCount(serviceInstance)
         }
+    }
+
+    int getActiveChildrenCount(ServiceInstance serviceInstance) {
+        List<ServiceInstance> undeletedChildren = serviceInstance.childs.findAll { si -> !si.deleted }
+        int completedUndeletedChildrenCount = undeletedChildren.count { si -> si.completed }
+
+        List<ServiceInstance> uncompletedChildren = undeletedChildren.findAll { si -> !si.completed }
+
+        int childrenProvisionInProgress = 0
+        uncompletedChildren.each {
+            si ->
+                def lastOperation = lastOperationRepository.findByGuid(si.guid)
+                if (lastOperation.status == LastOperation.Status.IN_PROGRESS) {
+                    childrenProvisionInProgress++
+                }
+        }
+
+        return completedUndeletedChildrenCount + childrenProvisionInProgress
     }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/ParentServiceProvider.groovy
@@ -1,10 +1,11 @@
 package com.swisscom.cloud.sb.broker.util
 
-import com.swisscom.cloud.sb.broker.model.LastOperation
 import com.swisscom.cloud.sb.broker.model.Parameter
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import com.swisscom.cloud.sb.broker.model.repository.LastOperationRepository
 import org.springframework.beans.factory.annotation.Autowired
+
+import static com.swisscom.cloud.sb.broker.model.LastOperation.Status.IN_PROGRESS
 
 trait ParentServiceProvider {
     private static final String MAX_CHILDREN = "max_children"
@@ -35,7 +36,7 @@ trait ParentServiceProvider {
         uncompletedChildren.each {
             si ->
                 def lastOperation = lastOperationRepository.findByGuid(si.guid)
-                if (lastOperation.status == LastOperation.Status.IN_PROGRESS) {
+                if (lastOperation.status == IN_PROGRESS) {
                     childrenProvisionInProgress++
                 }
         }

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningServiceSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/provisioning/ProvisioningServiceSpec.groovy
@@ -181,7 +181,8 @@ class ProvisioningServiceSpec extends Specification {
         given:
         def serviceProvider = Mock(ServiceProvider).withTraits(ParentServiceProvider)
         serviceProvider.lastOperationRepository = lastOperationRepository
-        lastOperationRepository.findByGuid(_) >> new LastOperation(status: LastOperation.Status.IN_PROGRESS)
+        def childServiceInstanceGuid = UUID.randomUUID().toString()
+        lastOperationRepository.findByGuid(childServiceInstanceGuid) >> new LastOperation(status: LastOperation.Status.IN_PROGRESS)
         def serviceProviderLookup = Mock(ServiceProviderLookup)
         serviceProviderLookup.findServiceProvider(_) >> serviceProvider
         provisioningService.serviceProviderLookup = serviceProviderLookup
@@ -189,7 +190,7 @@ class ProvisioningServiceSpec extends Specification {
         and:
         def parentServiceInstance = Mock(ServiceInstance)
         def plan = Mock(Plan)
-        parentServiceInstance.getChilds() >> new HashSet<ServiceInstance>([new ServiceInstance()])
+        parentServiceInstance.getChilds() >> new HashSet<ServiceInstance>([new ServiceInstance(guid: childServiceInstanceGuid)])
         plan.getGuid() >> "test"
         plan.getParameters() >> new HashSet<Parameter>([new Parameter(name: "max_children", value: 1)])
         parentServiceInstance.plan >> plan
@@ -213,7 +214,8 @@ class ProvisioningServiceSpec extends Specification {
         given:
         def serviceProvider = Mock(ServiceProvider).withTraits(ParentServiceProvider)
         serviceProvider.lastOperationRepository = lastOperationRepository
-        lastOperationRepository.findByGuid(_) >> new LastOperation(status: LastOperation.Status.IN_PROGRESS)
+        def childServiceInstanceGuid = UUID.randomUUID().toString()
+        lastOperationRepository.findByGuid(childServiceInstanceGuid) >> new LastOperation(status: LastOperation.Status.IN_PROGRESS)
         def serviceProviderLookup = Mock(ServiceProviderLookup)
         serviceProviderLookup.findServiceProvider(_) >> serviceProvider
         provisioningService.serviceProviderLookup = serviceProviderLookup
@@ -221,7 +223,7 @@ class ProvisioningServiceSpec extends Specification {
         and:
         def parentServiceInstance = Mock(ServiceInstance)
         def plan = Mock(Plan)
-        parentServiceInstance.getChilds() >> new HashSet<ServiceInstance>([new ServiceInstance()])
+        parentServiceInstance.getChilds() >> new HashSet<ServiceInstance>([new ServiceInstance(guid: childServiceInstanceGuid)])
         plan.getGuid() >> "test"
         plan.getParameters() >> new HashSet<Parameter>([new Parameter(name: "max_children", value: 2)])
         parentServiceInstance.plan >> plan
@@ -245,7 +247,8 @@ class ProvisioningServiceSpec extends Specification {
         given:
         def serviceProvider = Mock(ServiceProvider).withTraits(ParentServiceProvider)
         serviceProvider.lastOperationRepository = lastOperationRepository
-        lastOperationRepository.findByGuid(_) >> new LastOperation(status: LastOperation.Status.IN_PROGRESS)
+        def childServiceInstanceGuid = UUID.randomUUID().toString()
+        lastOperationRepository.findByGuid(childServiceInstanceGuid) >> new LastOperation(status: LastOperation.Status.IN_PROGRESS)
         def serviceProviderLookup = Mock(ServiceProviderLookup)
         serviceProviderLookup.findServiceProvider(_) >> serviceProvider
         provisioningService.serviceProviderLookup = serviceProviderLookup
@@ -257,7 +260,7 @@ class ProvisioningServiceSpec extends Specification {
         service.getAsyncRequired() >> false
         plan.service >> service
         serviceInstance.plan >> plan
-        serviceInstance.childs >> new HashSet<ServiceInstance>([new ServiceInstance(deleted: false)])
+        serviceInstance.childs >> new HashSet<ServiceInstance>([new ServiceInstance(deleted: false, guid: childServiceInstanceGuid)])
         def deprovisionRequest = new DeprovisionRequest(serviceInstanceGuid: serviceInstanceGuid, acceptsIncomplete: true, serviceInstance: serviceInstance)
         when:
         provisioningService.checkActiveChildren(deprovisionRequest)
@@ -269,7 +272,8 @@ class ProvisioningServiceSpec extends Specification {
         given:
         def serviceProvider = Mock(ServiceProvider).withTraits(ParentServiceProvider)
         serviceProvider.lastOperationRepository = lastOperationRepository
-        lastOperationRepository.findByGuid(_) >> new LastOperation(status: LastOperation.Status.FAILED)
+        def childServiceInstanceGuid = UUID.randomUUID().toString()
+        lastOperationRepository.findByGuid(childServiceInstanceGuid) >> new LastOperation(status: LastOperation.Status.FAILED)
         def serviceProviderLookup = Mock(ServiceProviderLookup)
         serviceProviderLookup.findServiceProvider(_) >> serviceProvider
         provisioningService.serviceProviderLookup = serviceProviderLookup
@@ -281,7 +285,7 @@ class ProvisioningServiceSpec extends Specification {
         service.getAsyncRequired() >> false
         plan.service >> service
         serviceInstance.plan >> plan
-        serviceInstance.childs >> new HashSet<ServiceInstance>([new ServiceInstance(deleted: false)])
+        serviceInstance.childs >> new HashSet<ServiceInstance>([new ServiceInstance(deleted: false, guid: childServiceInstanceGuid)])
         def deprovisionRequest = new DeprovisionRequest(serviceInstanceGuid: serviceInstanceGuid, acceptsIncomplete: true, serviceInstance: serviceInstance)
         when:
         provisioningService.checkActiveChildren(deprovisionRequest)


### PR DESCRIPTION
Make sure to only count created or creating children as active children and not children which have crashed during provision.