### PR TITLE
chore: Using jfrog gradle plugin to publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,18 @@
 plugins {
     id "com.jfrog.bintray" version "1.8.4" apply false
     id "com.jfrog.artifactory" version "4.9.5" apply false
+    id 'pl.allegro.tech.build.axion-release' version '1.10.0'
     id 'org.springframework.boot' version '2.1.1.RELEASE' apply false
     id "com.github.jk1.dependency-license-report" version "1.2"
 }
+
+apply from: "$rootDir/gradle/versioning.gradle"
 
 allprojects {
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'com.jfrog.artifactory'
     apply from: "$rootDir/gradle/artifactory.gradle"
-
+    project.version = scmVersion.version
 
 }
 
@@ -22,11 +25,12 @@ subprojects {
     group = 'com.swisscom.cloud.sb'
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
-    def brokerVersion = version
+
 
     apply from: "$rootDir/gradle/repositories.gradle"
     apply from: "$rootDir/gradle/dependencies.gradle"
     apply from: "$rootDir/gradle/publishing.gradle"
+    def brokerVersion = version
 }
 
 licenseReport {

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,23 @@
 plugins {
-    id 'nebula.info' version '5.0.0' apply false
-    id 'nebula.maven-publish' version '10.0.0' apply false
-    id 'nebula.javadoc-jar' version '10.0.0' apply false
-    id 'nebula.source-jar' version '10.0.0' apply false
-    id 'nebula.test-jar' version '10.0.0' apply false
-    id 'nebula.nebula-bintray' version '7.0.0' apply false
+    id "com.jfrog.bintray" version "1.8.4" apply false
+    id "com.jfrog.artifactory" version "4.9.5" apply false
     id 'org.springframework.boot' version '2.1.1.RELEASE' apply false
     id "com.github.jk1.dependency-license-report" version "1.2"
 }
 
-
 allprojects {
-    
+    apply plugin: 'com.jfrog.bintray'
+    apply plugin: 'com.jfrog.artifactory'
+    apply from: "$rootDir/gradle/artifactory.gradle"
+
+
 }
 
 subprojects {
     apply plugin: 'groovy'
     apply plugin: 'signing'
+    apply plugin: 'maven-publish'
+
 
     group = 'com.swisscom.cloud.sb'
     sourceCompatibility = 1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-version=6.3.0-SNAPSHOT
-
 # The following properties might improve the performance of the gradle build.
 # You could overwrite them:
 # - writing a gradle.properties in GRADLE_USER_HOME directory

--- a/gradle/artifactory.gradle
+++ b/gradle/artifactory.gradle
@@ -1,0 +1,59 @@
+artifactory {
+    contextUrl = 'http://oss.jfrog.org'
+    publish {
+        repository {
+            repoKey = 'oss-snapshot-local'
+            username = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+            password = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+        }
+        defaults {
+            publications ['maven']
+            publishArtifacts = true
+            publishPom = true
+        }
+    }
+    resolve {
+        repoKey = 'jcenter'
+    }
+    clientConfig.info.setBuildNumber(System.getProperty('build.number'))
+}
+
+/**
+ * For publishing in bintray and make it later sync with maven-central
+ */
+bintray {
+    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+    key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+    publications = ['maven']
+
+    pkg {
+        repo = "open-service-broker"
+        userOrg = "swisscom"
+        desc = description
+        websiteUrl = "https://github.com/swisscom/open-service-broker"
+        issueTrackerUrl = "https://github.com/swisscom/open-service-broker/issues"
+        vcsUrl = "https://github.com/swisscom/open-service-broker.git"
+        githubRepo = 'swisscom/open-service-broker'
+        licenses = ["Apache-2.0"]
+        labels = ["osb_api", "cloud_foundry"]
+        publicDownloadNumbers = true
+        attributes = [:]
+        version {
+            released = new Date()
+            name = project.version
+            vcsTag = project.version
+            attributes = [:]
+
+            // Optional configuration for Maven Central sync of the version
+            mavenCentralSync {
+                sync = true //[Default: true] Determines whether to sync the version to Maven Central.
+                close = '1'
+                //Optional property. By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off (by puting 0 as value) and release the version manually.
+                user = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') :
+                       System.getenv('SONATYPE_USER') //OSS user token: mandatory
+                password = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') :
+                           System.getenv('SONATYPE_PASSWORD') //OSS user password: mandatory
+            }
+        }
+    }
+}

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -13,12 +13,8 @@
  * specific language governing permissions and limitations under the License.
  */
 
-apply plugin: 'nebula.info'
-apply plugin: 'nebula.maven-publish'
-apply plugin: 'nebula.javadoc-jar'
-apply plugin: 'nebula.source-jar'
-apply plugin: 'nebula.test-jar'
-apply plugin: 'nebula.nebula-bintray-publishing'
+def isReleaseVersion = !version.endsWith('-SNAPSHOT')
+
 
 /**
  * Open service broker publication in maven central.
@@ -31,7 +27,7 @@ apply plugin: 'nebula.nebula-bintray-publishing'
  *  ossrhUsername=<oss.sonatype.org username>
  *  ossrhPassword=<oss.sonatype.org password>
  *
- *  // For compatibility with  bintray plugin
+ *  // For compatibility with bintray plugin
  *  bintrayUser=<bintray username>
  *  bintrayPassword=<bintray apikey obtained from ui>
  *
@@ -39,15 +35,36 @@ apply plugin: 'nebula.nebula-bintray-publishing'
  *  signingKeyId=<signing key id>
  *  signingPassword=<signing password>
  *  signingSecretKeyRingFile=<path tho the deencrypted secring.gpg.enc>
+ *      
+ *  References:
+ *  - https://reflectoring.io/publish-snapshots-with-gradle/
  */
-def isReleaseVersion = !version.endsWith('-SNAPSHOT')
 
+task sourcesJar(type: Jar) {
+    from sourceSets.main.allJava
+    archiveClassifier = 'sources'
+}
+
+task javadocJar(type: Jar) {
+    from javadoc
+    archiveClassifier = 'javadoc'
+}
+
+task testJar(type: Jar) {
+    from sourceSets.test.output
+    archiveClassifier = 'test'
+}
 
 publishing {
     publications {
-        nebula(MavenPublication) {
+        maven(MavenPublication) {
             artifactId = project.name
             groupId = group
+
+            from components.java
+            artifact sourcesJar
+            artifact javadocJar
+            artifact testJar
 
             pom {
                 name = project.name
@@ -93,26 +110,16 @@ publishing {
 
 }
 
-bintray {
-    user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-    apiKey = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
-
-    userOrg = "swisscom"
-    repo = "open-service-broker"
-    websiteUrl = "https://github.com/swisscom/open-service-broker"
-    issueTrackerUrl = "https://github.com/swisscom/open-service-broker/issues"
-    vcsUrl = "https://github.com/swisscom/open-service-broker.git"
-    licenses = ["Apache-2.0"]
-    labels = ["osb_api", "cloud_foundry"]
-}
-
-ext.'signing.keyId' = project.hasProperty('signingKeyId') ? project.property('signingKeyId') : System.getenv('SIGNING_KEY_ID')
-ext.'signing.password' = project.hasProperty('signingPassword') ? project.property('signingPassword') : System.getenv('SIGNING_PASSWORD')
-ext.'signing.secretKeyRingFile' = project.hasProperty('signingSecretKeyRingFile') ? project.property('signingSecretKeyRingFile') : "\$(pwd)/local.secring.gpg"
+ext.'signing.keyId' = project.hasProperty('signingKeyId') ? project.property('signingKeyId') :
+                      System.getenv('SIGNING_KEY_ID')
+ext.'signing.password' = project.hasProperty('signingPassword') ? project.property('signingPassword') :
+                         System.getenv('SIGNING_PASSWORD')
+ext.'signing.secretKeyRingFile' = project.hasProperty('signingSecretKeyRingFile') ? project.property(
+        'signingSecretKeyRingFile') : "\$(pwd)/local.secring.gpg"
 
 signing {
     required {isReleaseVersion}
-    sign publishing.publications.nebula
+    sign publishing.publications.maven
 }
 
 

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,0 +1,78 @@
+/**
+ * Using Axion release plugin(https://github.com/allegro/axion-release-plugin)
+ * <pre>id 'pl.allegro.tech.build.axion-release' version '1.10.0'</pre>
+ */
+scmVersion {
+
+    repository {
+        type = 'git' // type of repository
+        directory = project.rootProject.file('./') // repository location
+        remote = 'origin' // remote name
+
+        // Authorization: useless in our case because we can't use ssh keys
+        // customKey = 'AAasaDDSSD...' or project.file('myKey') // custom authorization key (file or String)
+        // customKeyPassword = 'secret' // key password
+    }
+
+    // For connecting to remote we should provide ssh keys or you have to call it passing the username an password
+    //    gradle release -Prelease.customUsername=$GIT_USERNAME -Prelease.customPassword=$GIT_PASSWORD
+    localOnly = false // connect to remote
+
+    ignoreUncommittedChanges = false // should uncommitted changes force version bump
+
+    useHighestVersion = false // Defaults as false, setting to true will find the highest visible version in the commit tree
+
+    sanitizeVersion = true // should created version be sanitized, true by default
+
+    tag {
+        prefix = 'v' // prefix to be used, 'release' by default
+        branchPrefix = [ // set different prefix per branch
+                         'legacy/.*' : 'legacy'
+        ]
+
+        versionSeparator = '' // separator between prefix and version number, '-' by default
+        //serialize = { tag, version -> ... } // creates tag name from raw version
+        //deserialize = { tag, position, tagName -> ... } // reads raw version from tag
+        //initialVersion = { tag, position -> ... } // returns initial version if none found, 0.1.0 by default
+    }
+
+    nextVersion {
+        suffix = 'alpha' // tag suffix
+        separator = '-' // separator between version and suffix
+        //serializer = { nextVersionConfig, version -> ... } // append suffix to version tag
+        //deserializer = { nextVersionConfig, position -> ... } // strip suffix off version tag
+    }
+
+    //versionCreator { version, position -> ... } // creates version visible for Gradle from raw version and current position in scm
+    versionCreator 'versionWithBranch' // use one of predefined version creators
+    branchVersionCreator = [ // use different creator per branch
+                             'feature/.*': 'versionWithBranch',
+                             'bug/.*': 'versionWithBranch',
+                             'refactor/.*': 'versionWithBranch',
+                             'chore/.*': 'versionWithBranch'
+
+    ]
+
+    //versionIncrementer {context, config -> ...} // closure that increments a version from the raw version, current position in scm and config
+    versionIncrementer 'incrementPatch' // use one of predefined version incrementing rules
+    branchVersionIncrementer = [ // use different incrementer per branch
+                                 'feature/.*': 'incrementMinor',
+                                 'bug/.*': 'incrementPatch',
+                                 'refactor/.*': 'incrementPatch',
+                                 'chore/.*': 'incrementPatch'
+    ]
+
+    //createReleaseCommit true // should create empty commit to annotate release in commit history, false by default
+    //releaseCommitMessage { version, position -> ... } // custom commit message if commits are created
+
+    checks {
+        uncommittedChanges = true // permanently disable uncommitted changes check
+        aheadOfRemote = false // permanently disable ahead of remote check
+        snapshotDependencies = false // check that there is no SNAPSHOT dependencies (for example when doing a stable release)
+    }
+
+    hooks {
+        pre 'fileUpdate', [file: 'README.md', pattern: {v,p -> ":version: (.*)"}, replacement: {v, p -> ":version: $v"}]
+        pre 'commit'
+    }
+}


### PR DESCRIPTION
We are having problems for publishing SNAPSHOTS at oss.jfrog.org with
nebula plugin, so we are trying to do it with the jfrog plugin.
Unfortunately our bintray users have some problem and the SNAPSHOT is
not published because a HTPP 403 Forbidden. Support ticket created in
JFrog.