### PR TITLE
fix: remove access modifier for GenericConfig properties

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/GenericConfig.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/GenericConfig.groovy
@@ -4,6 +4,6 @@ import groovy.transform.CompileStatic
 
 @CompileStatic
 class GenericConfig {
-    public String templateName
-    public String type
+    String templateName
+    String type
 }

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/bosh/DummyBoshBasedServiceConfig.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/bosh/DummyBoshBasedServiceConfig.groovy
@@ -15,11 +15,14 @@
 
 package com.swisscom.cloud.sb.broker.services.bosh
 
-import com.swisscom.cloud.sb.broker.cfextensions.endpoint.EndpointConfig
+import com.swisscom.cloud.sb.broker.services.AsyncServiceConfigImpl
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 
-trait BoshBasedServiceConfig implements EndpointConfig, BoshConfig {
-    String portRange
-    String boshManifestFolder
-    boolean shuffleAzs
-    List<GenericConfig> genericConfigs = new ArrayList<>()
+@Configuration
+@ConfigurationProperties(prefix = "com.swisscom.cloud.sb.broker.service.test-bosh-based-service")
+@Profile("test")
+class DummyBoshBasedServiceConfig extends AsyncServiceConfigImpl implements BoshBasedServiceConfig {
+
 }

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/bosh/DummyBoshBasedServiceConfigTest.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/bosh/DummyBoshBasedServiceConfigTest.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.swisscom.cloud.sb.broker.services.bosh
+
+import com.swisscom.cloud.sb.broker.BaseSpecification
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles(profiles = "default,test")
+class DummyBoshBasedServiceConfigTest extends BaseSpecification {
+
+    @Autowired
+    DummyBoshBasedServiceConfig dummyBoshBasedServiceConfig
+
+    def "DummyBoshBasedServiceConfig is loaded correctly"() {
+        when:
+        println("dummyBoshBasedServiceConfig should be loaded by Spring Auto Configuration")
+        then:
+        assert dummyBoshBasedServiceConfig.genericConfigs != null
+        assert dummyBoshBasedServiceConfig.retryIntervalInSeconds == 42
+        assert dummyBoshBasedServiceConfig.genericConfigs[0].templateName == 'test'
+        assert dummyBoshBasedServiceConfig.genericConfigs[0].type == 'cloud'
+    }
+}

--- a/broker/src/integration-test/resources/application-test.yml
+++ b/broker/src/integration-test/resources/application-test.yml
@@ -58,6 +58,12 @@ com.swisscom.cloud.sb.broker.service.mariadb:
       bindir: '/var/vcap/packages/shield-mysql/bin'
       dashboardPath:
 
+com.swisscom.cloud.sb.broker.service.test-bosh-based-service:
+  retryIntervalInSeconds: 42
+  genericConfigs:
+    - templateName: test
+      type: cloud
+
 com.swisscom.cloud.sb.broker.bosh.credhub:
   enable: false
   url: https://localhost:9000


### PR DESCRIPTION
Spring configuration properties need setters, which are only generated by Groovy when no access modifier is present.