### PR TITLE
fix: Align micrometer-registry-influx to v1.1.1

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -30,7 +30,7 @@ ext {
             tomcat_juli                        : '9.0.11',
 
             influxdb_java                      : '2.7',
-            micrometer_registry_influx         : '1.0.4',
+            micrometer_registry_influx         : '1.1.1',
 
             springfox                          : '2.9.2',
             swagger                            : '2.0.2',


### PR DESCRIPTION
We were having two different versions (1.0.4 and 1.1.1) of
micrometer-registry-influx which was causing a classpath problem.