### PR TITLE
Feature/change release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,44 +4,77 @@
 #
 version: 2
 jobs:
+  # For building and launching the unit tests we only need a docker image with OpenJDK v8 on it
   build:
+    docker:
+      - image: circleci/openjdk:8
+    environment:
+        JAVA_TOOL_OPTIONS: -Xmx1024m
+        SPRING_PROFILES_ACTIVE: info,default,extensions,secrets,test
+    steps:
+      - checkout
+      - run: ./gradlew build -x integrationTest -x functionalTest --stacktrace
+
+  # For integration testing we need to start a machine or setup_remote_docker because we need to use docker-compose for
+  # having services up to launch the tests against
+  integration_test:
     machine:
       image: circleci/classic:latest
-
     working_directory: ~/repo
-
     environment:
       JAVA_TOOL_OPTIONS: -Xmx1024m
       SPRING_PROFILES_ACTIVE: info,default,extensions,secrets,test
-
     steps:
-    - checkout
-    - run: sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-    - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
-    - run: 'if [[ -z "${CIRCLE_PULL_REQUEST}" ]]; then openssl aes-256-cbc -md md5 -pass pass:$ENCRYPTION_PASSWORD -in secring.gpg.enc -out local.secring.gpg -d; fi'
-    - run: pushd docker && ./setup_docker.sh ; popd
-    - run: ./gradlew clean build -x functionalTest --stacktrace
-    - run: ./scripts/circleci-publish.sh
+      - checkout
+      - run: sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
+      - run: 'if [[ -z "${CIRCLE_PULL_REQUEST}" ]]; then openssl aes-256-cbc -md md5 -pass pass:$ENCRYPTION_PASSWORD -in secring.gpg.enc -out local.secring.gpg -d; fi'
+      - run: pushd docker && ./setup_docker.sh ; popd
+      - run: ./gradlew clean build -x functionalTest --stacktrace
 
-  release:
+  # For tagging in the repository tags in the form 'vn.minor+1.0' or in the form 'vn.nn.patch+1'
+  tag_release:
     docker:
-    - image: circleci/buildpack-deps
-
+      - image: circleci/openjdk:8
     steps:
-    - checkout
-    - add_ssh_keys:
-        fingerprints:
-          - "c7:88:38:13:95:28:53:68:f3:2e:73:ee:e4:c9:5d:66"
-    - run: ./scripts/bump_and_create_release.sh
+      - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "c7:88:38:13:95:28:53:68:f3:2e:73:ee:e4:c9:5d:66"
+      - run: |
+          VERSION_INCREMENTER=$(git log --pretty=%B -1 | cat | grep -q  "feature/"  && echo "incrementMinor" || echo "incrementPatch")
+          ./gradlew release -Prelease.versionIncrementer=$VERSION_INCREMENTER -Prelease.customUsername=$GITHUB_USER -Prelease.customPassword=$GITHUB_PASSWORD
+
+
+  # For publishing build artifacts in MavenCentral and JCenter
+  publish:
+    docker:
+      - image: circleci/openjdk:8
+    steps:
+      - checkout
+      - run: ./gradlew publish
+
 
 workflows:
   version: 2
-  build:
+  build_test_tag_publish:
     jobs:
       - build
-      - release:
+      - integration_test:
           requires:
             - build
+      - tag_release:
+          requires:
+            - integration_test
           filters:
             branches:
               only: develop
+      - publish:
+          requires:
+            - integration_test
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
+

--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: "org.springframework.boot"
 apply plugin: "io.spring.dependency-management"
 
-apply from: "$rootDir/gradle/functional-testing.gradle"
-
 jar {
     enabled = true
 }

--- a/broker/core/build.gradle
+++ b/broker/core/build.gradle
@@ -4,6 +4,21 @@ jar{
     enabled = true
 }
 
+// We need to define test artifacts because broker tests extend from AbstractAsyncServiceProviderSpec
+// FIXME Use Junit Rules instead of extending AbstractAsyncServiceProviderSpec
+configurations {
+    testArtifacts.extendsFrom testRuntime
+}
+
+task testJar(type: Jar) {
+    classifier "test"
+    from sourceSets.test.output
+}
+
+artifacts {
+    testArtifacts testJar
+}
+
 dependencies {
     compile project(':model')
     compile project(':client')
@@ -51,12 +66,4 @@ dependencies {
     testCompile libs.groovy_test
     testCompile libs.spring_boot_starter_test
     
-}
-
-configurations{
-    testArtifacts.extendsFrom testRuntime
-}
-
-artifacts {
-    testArtifacts testJar
 }

--- a/build.gradle
+++ b/build.gradle
@@ -10,26 +10,26 @@ plugins {
     id "com.github.jk1.dependency-license-report" version "1.2"
 }
 
-
+// According to axion documentation you should apply the scmVersion configuration in the root project and associate
+// the calculated version to subprojects
+// https://axion-release-plugin.readthedocs.io/en/latest/configuration/basic_usage/#multi-module-with-multiple-versions
 apply from: "$rootDir/gradle/versioning.gradle"
 
 allprojects {
     project.version = scmVersion.version
-
 }
 
 subprojects {
-    apply plugin: 'groovy'
     apply plugin: 'signing'
+    apply plugin: 'groovy'
+    apply from: "$rootDir/gradle/repositories.gradle"
+    apply from: "$rootDir/gradle/dependencies.gradle"
+    apply from: "$rootDir/gradle/functional-testing.gradle"
 
     group = 'com.swisscom.cloud.sb'
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
     def brokerVersion = version
-
-    apply from: "$rootDir/gradle/repositories.gradle"
-    apply from: "$rootDir/gradle/dependencies.gradle"
-    apply from: "$rootDir/gradle/publishing.gradle"
 }
 
 licenseReport {

--- a/build.gradle
+++ b/build.gradle
@@ -5,13 +5,17 @@ plugins {
     id 'nebula.source-jar' version '10.0.0' apply false
     id 'nebula.test-jar' version '10.0.0' apply false
     id 'nebula.nebula-bintray' version '7.0.0' apply false
+    id 'pl.allegro.tech.build.axion-release' version '1.10.0'
     id 'org.springframework.boot' version '2.1.1.RELEASE' apply false
     id "com.github.jk1.dependency-license-report" version "1.2"
 }
 
 
+apply from: "$rootDir/gradle/versioning.gradle"
+
 allprojects {
-    
+    project.version = scmVersion.version
+
 }
 
 subprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,3 @@
-version=6.3.0-SNAPSHOT
-
 # The following properties might improve the performance of the gradle build.
 # You could overwrite them:
 # - writing a gradle.properties in GRADLE_USER_HOME directory

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -8,10 +8,7 @@ scmVersion {
         type = 'git' // type of repository
         directory = project.rootProject.file('./') // repository location
         remote = 'origin' // remote name
-
-        // Authorization: useless in our case because we can't use ssh keys
-        // customKey = 'AAasaDDSSD...' or project.file('myKey') // custom authorization key (file or String)
-        // customKeyPassword = 'secret' // key password
+        pushTagsOnly = true
     }
 
     // For connecting to remote we should provide ssh keys or you have to call it passing the username an password
@@ -20,7 +17,8 @@ scmVersion {
 
     ignoreUncommittedChanges = false // should uncommitted changes force version bump
 
-    useHighestVersion = false // Defaults as false, setting to true will find the highest visible version in the commit tree
+    useHighestVersion = false
+    // Defaults as false, setting to true will find the highest visible version in the commit tree
 
     sanitizeVersion = true // should created version be sanitized, true by default
 
@@ -66,13 +64,14 @@ scmVersion {
     //releaseCommitMessage { version, position -> ... } // custom commit message if commits are created
 
     checks {
-        uncommittedChanges = true // permanently disable uncommitted changes check
+        uncommittedChanges = false // permanently disable uncommitted changes check
         aheadOfRemote = false // permanently disable ahead of remote check
-        snapshotDependencies = false // check that there is no SNAPSHOT dependencies (for example when doing a stable release)
+        snapshotDependencies = false
+        // check that there is no SNAPSHOT dependencies (for example when doing a stable release)
     }
 
-    hooks {
-        pre 'fileUpdate', [file: 'README.md', pattern: {v,p -> ":version: (.*)"}, replacement: {v, p -> ":version: $v"}]
-        pre 'commit'
-    }
+//    hooks {
+//        pre 'fileUpdate', [file: 'README.md', pattern: {v,p -> ":version: (.*)"}, replacement: {v, p -> ":version: $v"}]
+//        pre 'commit'
+//    }
 }

--- a/gradle/versioning.gradle
+++ b/gradle/versioning.gradle
@@ -1,0 +1,78 @@
+/**
+ * Using Axion release plugin(https://github.com/allegro/axion-release-plugin)
+ * <pre>id 'pl.allegro.tech.build.axion-release' version '1.10.0'</pre>
+ */
+scmVersion {
+
+    repository {
+        type = 'git' // type of repository
+        directory = project.rootProject.file('./') // repository location
+        remote = 'origin' // remote name
+
+        // Authorization: useless in our case because we can't use ssh keys
+        // customKey = 'AAasaDDSSD...' or project.file('myKey') // custom authorization key (file or String)
+        // customKeyPassword = 'secret' // key password
+    }
+
+    // For connecting to remote we should provide ssh keys or you have to call it passing the username an password
+    //    gradle release -Prelease.customUsername=$GIT_USERNAME -Prelease.customPassword=$GIT_PASSWORD
+    localOnly = false // connect to remote
+
+    ignoreUncommittedChanges = false // should uncommitted changes force version bump
+
+    useHighestVersion = false // Defaults as false, setting to true will find the highest visible version in the commit tree
+
+    sanitizeVersion = true // should created version be sanitized, true by default
+
+    tag {
+        prefix = 'v' // prefix to be used, 'release' by default
+        branchPrefix = [ // set different prefix per branch
+                         'legacy/.*' : 'legacy'
+        ]
+
+        versionSeparator = '' // separator between prefix and version number, '-' by default
+        //serialize = { tag, version -> ... } // creates tag name from raw version
+        //deserialize = { tag, position, tagName -> ... } // reads raw version from tag
+        //initialVersion = { tag, position -> ... } // returns initial version if none found, 0.1.0 by default
+    }
+
+    nextVersion {
+        suffix = 'alpha' // tag suffix
+        separator = '-' // separator between version and suffix
+        //serializer = { nextVersionConfig, version -> ... } // append suffix to version tag
+        //deserializer = { nextVersionConfig, position -> ... } // strip suffix off version tag
+    }
+
+    //versionCreator { version, position -> ... } // creates version visible for Gradle from raw version and current position in scm
+    versionCreator 'versionWithBranch' // use one of predefined version creators
+    branchVersionCreator = [ // use different creator per branch
+                             'feature/.*': 'versionWithBranch',
+                             'bug/.*': 'versionWithBranch',
+                             'refactor/.*': 'versionWithBranch',
+                             'chore/.*': 'versionWithBranch'
+
+    ]
+
+    //versionIncrementer {context, config -> ...} // closure that increments a version from the raw version, current position in scm and config
+    versionIncrementer 'incrementPatch' // use one of predefined version incrementing rules
+    branchVersionIncrementer = [ // use different incrementer per branch
+                                 'feature/.*': 'incrementMinor',
+                                 'bug/.*': 'incrementPatch',
+                                 'refactor/.*': 'incrementPatch',
+                                 'chore/.*': 'incrementPatch'
+    ]
+
+    //createReleaseCommit true // should create empty commit to annotate release in commit history, false by default
+    //releaseCommitMessage { version, position -> ... } // custom commit message if commits are created
+
+    checks {
+        uncommittedChanges = true // permanently disable uncommitted changes check
+        aheadOfRemote = false // permanently disable ahead of remote check
+        snapshotDependencies = false // check that there is no SNAPSHOT dependencies (for example when doing a stable release)
+    }
+
+    hooks {
+        pre 'fileUpdate', [file: 'README.md', pattern: {v,p -> ":version: (.*)"}, replacement: {v, p -> ":version: $v"}]
+        pre 'commit'
+    }
+}


### PR DESCRIPTION
We are moving from our current release workflow (that is making `master` and `develop` diverge and not tagging correctly) to a workflow based purely in gradle plugins for [versioning](https://github.com/allegro/axion-release-plugin/) and [publishing](https://github.com/nebula-plugins/nebula-publishing-plugin).

Some of the benefits will be:
- Less noise in the commit history of the project
- Tags will be pointing to real commits in `develop`
- Try to unify the diverged history of `master` and `develop`