### PR TITLE
fix: Make the tags done in develop launch publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
             - integration_test
           filters:
             branches:
-              ignore: /.*/
+              only: develop
             tags:
               only: /v.*/
 


### PR DESCRIPTION
Correcting the circle-ci workflow to launch builds that publish the tags
done in develop