### PR TITLE
fix: Correct nebula publishing configuration

### DIFF
--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     runtime libs.javax_el_api
     runtime libs.javax_el
 
-    testCompile project(path:':broker:core', configuration:'testArtifacts')
+    testCompile project(path:':broker:core', configuration:'test')
     testCompile libs.groovy
     testCompile libs.groovy_test
     testCompile libs.junit

--- a/broker/core/build.gradle
+++ b/broker/core/build.gradle
@@ -4,21 +4,6 @@ jar{
     enabled = true
 }
 
-// We need to define test artifacts because broker tests extend from AbstractAsyncServiceProviderSpec
-// FIXME Use Junit Rules instead of extending AbstractAsyncServiceProviderSpec
-configurations {
-    testArtifacts.extendsFrom testRuntime
-}
-
-task testJar(type: Jar) {
-    classifier "test"
-    from sourceSets.test.output
-}
-
-artifacts {
-    testArtifacts testJar
-}
-
 dependencies {
     compile project(':model')
     compile project(':client')

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ subprojects {
     apply from: "$rootDir/gradle/repositories.gradle"
     apply from: "$rootDir/gradle/dependencies.gradle"
     apply from: "$rootDir/gradle/functional-testing.gradle"
+    apply from: "$rootDir/gradle/publishing.gradle"
 
     group = 'com.swisscom.cloud.sb'
     sourceCompatibility = 1.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+group=com.swisscom.cloud.sb
+publishingName=Open Service Broker
+publishingDescription=Enables cloud platforms to provide and manages services implementing OSB api
+
 # The following properties might improve the performance of the gradle build.
 # You could overwrite them:
 # - writing a gradle.properties in GRADLE_USER_HOME directory


### PR DESCRIPTION
I added the configuration we are using internally for publishing other
projects. I had to include some new project properties at gradle
properties for correct maven pom generation and take out the generation
of test artifacts at the broker core because nebula.test-jar plugin is
the one that is introducing this kind of hack (we should not depend in
test jars)