### PR TITLE
chore: Make publishing be done after tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,7 @@ workflows:
       - publish:
           requires:
             - integration_test
+            - tag_release
           filters:
             branches:
               only: develop


### PR DESCRIPTION
The idea is a sequential workflow, we can't publish and tag in parallel.