### PR TITLE
chore: Pass bintray credentials as env variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - image: circleci/openjdk:8
     steps:
       - checkout
-      - run: ./gradlew publish
+      - run: ./gradlew publish -PbintrayUser=$BINTRAY_USER -PbintrayApiKey=$BINTRAY_API_KEY
 
 
 workflows:


### PR DESCRIPTION
It looks that System.getenv('BINTRAY_USER') of our publishing.gradle is
not working in circleci environment (maybe because is a docker container
with different env?). Now we are passing directly to gradle publish
those credentials already stored in circle-ci.