### PR TITLE
fix: Rename 'spring.credhub.enable` to osb.c.e

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceImpl.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceImpl.groovy
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Service
 @Service
 @CompileStatic
 @Slf4j
-@ConditionalOnProperty(name = "spring.credhub.enable", havingValue = "true")
+@ConditionalOnProperty(name = "osb.credhub.enable", havingValue = "true")
 class CredHubServiceImpl implements CredHubService {
 
     @Autowired

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceProvider.groovy
@@ -46,7 +46,7 @@ import static com.swisscom.cloud.sb.broker.services.credhub.CredHubServiceDetail
 @Component
 @CompileStatic
 @Slf4j
-@ConditionalOnProperty(name = "spring.credhub.enable", havingValue = "true")
+@ConditionalOnProperty(name = "osb.credhub.enable", havingValue = "true")
 class CredHubServiceProvider implements ServiceProvider, SensitiveParameterProvider, CloudFoundryContextRestrictedOnly {
 
     private final CredHubServiceImpl credHubServiceImpl

--- a/broker/core/src/main/resources/application.yml
+++ b/broker/core/src/main/resources/application.yml
@@ -2,13 +2,16 @@ spring.profiles:
   include:
   - activeprofiles
 ---
+osb:
+  credhub:
+    enable: false
+
 spring:
   profiles: default
 
   credhub:
     url:
     oauth2.registration-id:
-    enable: false
   security:
     oauth2:
       client:

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/CredHubBindingParametersFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/CredHubBindingParametersFunctionalSpec.groovy
@@ -104,7 +104,7 @@ class CredHubBindingParametersFunctionalSpec extends BaseFunctionalSpec {
         YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean()
         yaml.setResources(new ClassPathResource("application-broker.yml"))
         yaml.afterPropertiesSet()
-        return StringUtils.equals(yaml.object.getProperty("spring.credhub.enable"), "true")
+        return StringUtils.equals(yaml.object.getProperty("osb.credhub.enable"), "true")
     }
 
 }

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/CredHubServiceProviderFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/CredHubServiceProviderFunctionalSpec.groovy
@@ -131,6 +131,6 @@ class CredHubServiceProviderFunctionalSpec extends BaseFunctionalSpec {
         YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean()
         yaml.setResources(new ClassPathResource("application-test.yml"))
         yaml.afterPropertiesSet()
-        return StringUtils.equals(yaml.object.getProperty("spring.credhub.enable"), "true")
+        return StringUtils.equals(yaml.object.getProperty("osb.credhub.enable"), "true")
     }
 }

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubIntegrationSpec.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubIntegrationSpec.groovy
@@ -204,7 +204,7 @@ class CredHubIntegrationSpec extends BaseSpecification {
         YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean()
         yaml.setResources(new ClassPathResource("application-test.yml"))
         yaml.afterPropertiesSet()
-        return StringUtils.equals(yaml.object.getProperty("spring.credhub.enable"), "true")
+        return StringUtils.equals(yaml.object.getProperty("osb.credhub.enable"), "true")
     }
 
 }


### PR DESCRIPTION
If you are using `spring.credhub` property path, Spring tries to
configure credhub beans. And if enable=false, first it configures beans
that are NOT going to be used and that probably are not correctly
configured.

Changing the name of the watched property in the @OnProperty makes all
the problems go away.