### PR TITLE
chore: fix Gradle publishing for OSB developer README

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -33,7 +33,7 @@ apply plugin: 'nebula.nebula-bintray-publishing'
  *
  *  // For compatibility with  bintray plugin
  *  bintrayUser=<bintray username>
- *  bintrayPassword=<bintray apikey obtained from ui>
+ *  bintrayApiKey=<bintray apikey obtained from ui>
  *
  *  // For signing artifacts with deencrypted secring.gpg.enc
  *  signingKeyId=<signing key id>


### PR DESCRIPTION
fix parameter name `bintrayPassword` to `bintrayApiKey`