### PR TITLE
refactor/convert credhub test to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,20 @@ jobs:
       - checkout
       - run: ./gradlew build -x integrationTest -x functionalTest --stacktrace
 
+  # The new integration tests annotated with IntegrationTest and using testcontainers for launching the docker tests
+  it:
+    machine:
+      image: circleci/classic:latest
+    working_directory: ~/repo
+    environment:
+        JAVA_TOOL_OPTIONS: -Xmx1024m
+        SPRING_PROFILES_ACTIVE: info,default,extensions,secrets,test
+    steps:
+      - checkout
+      - run: sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
+      - run: ./gradlew it --stacktrace
+
   # For integration testing we need to start a machine or setup_remote_docker because we need to use docker-compose for
   # having services up to launch the tests against
   integration_test:
@@ -60,9 +74,11 @@ workflows:
   build_test_tag_publish:
     jobs:
       - build
+      - it
       - integration_test:
           requires:
             - build
+            - it
       - tag_release:
           requires:
             - integration_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
       - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
       - run: pushd docker && ./setup_docker.sh ; popd
-      - run: ./gradlew clean build -x functionalTest --stacktrace
+      - run: ./gradlew integrationTest -x functionalTest --stacktrace
 
   # For tagging in the repository tags in the form 'vn.minor+1.0' or in the form 'vn.nn.patch+1'
   tag_release:

--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     testCompile libs.cglib
     testCompile libs.groovy_test
     testCompile libs.spring_boot_starter_test
+    
 }
 
 ext {

--- a/broker/core/build.gradle
+++ b/broker/core/build.gradle
@@ -50,5 +50,7 @@ dependencies {
     testCompile libs.cglib
     testCompile libs.groovy_test
     testCompile libs.spring_boot_starter_test
+    testCompile libs.test_containers
+    testCompile libs.test_containers_spock
     
 }

--- a/broker/docker/docker-compose-test.yml
+++ b/broker/docker/docker-compose-test.yml
@@ -1,0 +1,33 @@
+version: '2'
+
+services:
+  mariadb:
+    image: mariadb:10
+    ports:
+    - "3306:3306"
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ROOT_PASSWORD: ''
+      MYSQL_DATABASE: CFBroker
+
+  uaa:
+    image: pcfseceng/uaa
+    container_name: uaa
+    volumes:
+      - ./uaa.yml:/uaa/uaa.yml
+    ports:
+      - "9081:8080"
+    restart: always
+
+  credhub:
+    image: ampersand8/credhub
+    container_name: credhub
+    ports:
+      - "9000:9000"
+    links:
+      - uaa:uaa
+    depends_on:
+      - uaa
+    environment:
+      UAA_URL: http://localhost:9081/uaa
+      UAA_INTERNAL_URL: http://uaa:8080/uaa

--- a/broker/docker/uaa.yml
+++ b/broker/docker/uaa.yml
@@ -1,0 +1,61 @@
+scim:
+  users:
+    - credhub|password|credhub|Credhub|User|credhub.read,credhub.write
+oauth:
+  clients:
+    credhub_cli:
+      override: true
+      authorized-grant-types: password,refresh_token
+      # scopes the client may receive
+      scope: credhub.read,credhub.write
+      authorities: uaa.resource
+      access-token-validity: 86400 # 1 day
+      refresh-token-validity: 172800 # re-login required every other day
+      secret: "" # CLI expects this secret to be empty
+    credhub_client:
+      override: true
+      authorized-grant-types: client_credentials
+      secret: secret
+      scope: uaa.none
+      authorities: credhub.read,credhub.write
+      access-token-validity: 86400 # 1 day
+jwt:
+  token:
+    verification-key: |
+      -----BEGIN PUBLIC KEY-----
+      MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyEsIhHyxd2xwI1AqZkma
+      OzqvyrLVJiYXhNc555MWCa+cOP/YcGY8htZS1Z0r3t9o9pHcFmUe5BTgrlMRnvQC
+      04SFV1hS+hs1Pct9E//Fcf/Db2AmbWhAZjki9McE+40DeXz5sjRMKxzVXnNDEJVm
+      Ucr6T65PRdIzKud00JBvkhD2ZIodVh6TUjP8fJIB8BJVZagUQwhBpIOODwgc165g
+      SAn0TwAtrj9SFDy64i74kOPlF8wZ26JIPebisIMDBQmzzp9zoPZ9sSD3yo7bGdXp
+      UPu94Z3/oU7e3YnA3BFpryjuFogpq8/9MPb2cKhENywTr0ljF0zHaazKViPiTwfu
+      cwIDAQAB
+      -----END PUBLIC KEY-----
+    signing-key: |
+      -----BEGIN RSA PRIVATE KEY-----
+      MIIEowIBAAKCAQEAyEsIhHyxd2xwI1AqZkmaOzqvyrLVJiYXhNc555MWCa+cOP/Y
+      cGY8htZS1Z0r3t9o9pHcFmUe5BTgrlMRnvQC04SFV1hS+hs1Pct9E//Fcf/Db2Am
+      bWhAZjki9McE+40DeXz5sjRMKxzVXnNDEJVmUcr6T65PRdIzKud00JBvkhD2ZIod
+      Vh6TUjP8fJIB8BJVZagUQwhBpIOODwgc165gSAn0TwAtrj9SFDy64i74kOPlF8wZ
+      26JIPebisIMDBQmzzp9zoPZ9sSD3yo7bGdXpUPu94Z3/oU7e3YnA3BFpryjuFogp
+      q8/9MPb2cKhENywTr0ljF0zHaazKViPiTwfucwIDAQABAoIBAQC2xNlp5Esg2d/e
+      KXn3SvSlVaEyS0v7esj9XFSnf22duxTIYpaDwpc6x3phGQH+Z0llrqXx/aZZpL99
+      86lhrfKiRwxSLvPQ7GECGZzyUfQ/WY9iI5ANSBNz9HF0geOHFB92jddgiR50PORr
+      QqyRBnOO8bTGXx5RbUVpwjmzVAmrc5cn0I2PyADDxRKfAPdIzbT4ukk4y08DSf2d
+      3oHf4E0t8F7uxaNN1L3iRuo75JbGApHlvuN2nmO7smMgFaHvVXcAql4O5qgb1s08
+      vxk7Hmmyy4JDLw8GQWWSjzMS7laL2P4gRRD4Rv5GV9AA7BkP4TXsEazSv0y2ygVJ
+      P2o6G2XZAoGBAO+RqHoIGv2m25BupSPJMO5DnQDaSURqXnvznejAYriQwxlIgIQb
+      QM69qkLcA9PxMGqvGMwUS4aF8/Jrg3pFQrqqK9JZUqRqIMIRP3BIbk9l5cILDwoR
+      UNlE+0v5fPCa7RP9MVM7DbqcOhoYPQ+WYNcd+tB1Hwd+HRZL7TVmI6ldAoGBANYH
+      xV3NMAMNIXBWzVJooMyWqFdYCCbc92DzNJwlJ99SS+YYP5aWUfMmif2m5KzdIdti
+      EyPFD+r2gt65oKKAiVM5r88/1mZVZJr00KpJjaCva5f5d2JoM39TtenfUyoLFE1u
+      74ndjbQLXEX4E4/pCdjnE8Kqag8NnrGtAIxGiuoPAoGAG1E/pdKgyUWqibikKgV6
+      B+E72OoLKrr6VSX9Xpn5Z9RR+uMSjH3TEP/9lywhX5yECdY3fKXfytIhdAYgcuPM
+      7R4UayL2UnsrixWOZ05LDdCvt0WtjFdXIb9E7G/heEoiOIJJipUURrAjy+/xnoJm
+      PoFTpUuFo0QVKwKzZMBl1p0CgYB3zj/Hgw0GGDqIlL44DAM+onK2+bsObhA3f8wK
+      P64zDvEXaqlllN1om0EQ8HP+44WJNTv7gNqpLrYREJ1/eS3lnVvxSg2smM5JAxMu
+      zx9tO+ShXG5ccnGpK2Wf9XerCCqkMZ36cT9Z8iYDsJraqprthGQGSrg1lu0nDe1J
+      mE84NwKBgFkOV3DcMOgUfPDA/goiBkiZnv8nFAebgYsSHrePjL3DOKV2agCuXDjO
+      LqSIlJ1UdBuWc6JWyQHn9x7t72acsRrtpRP4y4CQU5281/QcGqxCEcAGeTw1W9ni
+      HsxZCNa+Lefc/Qe9qao7x636FtQtMfkb76EMxduFawhgHuDQ53/j
+      -----END RSA PRIVATE KEY-----

--- a/broker/src/integration-test/resources/application-test.yml
+++ b/broker/src/integration-test/resources/application-test.yml
@@ -1,4 +1,9 @@
 ---
+# Sets the Credential Store to a CredHub instance
+osb:
+  credential:
+    store: "default"
+
 spring:
   profiles: test
   jpa.properties.hibernate.id.new_generator_mappings: false
@@ -11,26 +16,26 @@ spring:
     username: root
     password:
 
-  credhub:
-    url: https://localhost:9000
-    oauth2.registration-id: credhub-client
-  security:
-    oauth2:
-      client:
-        registration:
-          credhub-client:
-            provider: uaa
-            client-id: credhub_client
-            client-secret: secret
-            authorization-grant-type: client_credentials
-          bosh-client:
-            provider: uaa
-            client-id: credhub_client
-            client-secret: secret
-            authorization-grant-type: client_credentials
-        provider:
-          uaa:
-            token-uri: http://localhost:8081/uaa/oauth/token
+#  credhub:
+#    url: https://localhost:9000
+#    oauth2.registration-id: credhub-client
+#  security:
+#    oauth2:
+#      client:
+#        registration:
+#          credhub-client:
+#            provider: uaa
+#            client-id: credhub_client
+#            client-secret: secret
+#            authorization-grant-type: client_credentials
+#          bosh-client:
+#            provider: uaa
+#            client-id: credhub_client
+#            client-secret: secret
+#            authorization-grant-type: client_credentials
+#        provider:
+#          uaa:
+#            token-uri: http://localhost:8081/uaa/oauth/token
 
 com.swisscom.cloud.sb.broker.security.platformUsers:
   - username: cc_admin
@@ -64,10 +69,10 @@ com.swisscom.cloud.sb.broker.service.test-bosh-based-service:
     - templateName: test
       type: cloud
 
-com.swisscom.cloud.sb.broker.bosh.credhub:
-  enable: false
-  url: https://localhost:9000
-  oauth2.registration-id: bosh-client
+#com.swisscom.cloud.sb.broker.bosh.credhub:
+#  enable: false
+#  url: https://localhost:9000
+#  oauth2.registration-id: bosh-client
 
 com.swisscom.cloud.sb.broker.serviceDefinitions: [
 {

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBConfig.groovy
@@ -17,8 +17,9 @@ package com.swisscom.cloud.sb.broker.services.mariadb
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
 
-@Configuration
+@Component
 @ConfigurationProperties(prefix = 'com.swisscom.cloud.sb.broker.service.mariadb')
 class MariaDBConfig {
     String nameOfDefault

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProvider.groovy
@@ -36,10 +36,12 @@ import com.swisscom.cloud.sb.model.usage.ServiceUsage
 import com.swisscom.cloud.sb.model.usage.ServiceUsageType
 import groovy.transform.CompileStatic
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
 @CompileStatic
+@ConditionalOnProperty(name = 'com.swisscom.cloud.sb.broker.service.mariadb.clusters')
 class MariaDBServiceProvider extends RelationalDbServiceProvider implements ShieldBackupRestoreProvider, ServiceUsageProvider {
     private MariaDBConfig mariaDBConfig
 

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/AbstractCredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/AbstractCredHubSpec.groovy
@@ -1,0 +1,48 @@
+package com.swisscom.cloud.sb.broker.services.credhub
+
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import spock.lang.Specification
+
+abstract class AbstractCredHubSpec extends Specification{
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractCredHubSpec.class)
+
+
+    public static final DockerComposeContainer CREDHUB_UAA_MARIADB_CONTAINER
+
+    static{
+        CREDHUB_UAA_MARIADB_CONTAINER = new DockerComposeContainer(new File("docker/docker-compose-test.yml"))
+                .withExposedService(
+                        "mariadb",
+                        3306,
+                        Wait.forListeningPort())
+                .withExposedService(
+                        "credhub",
+                        9000,
+                        Wait.forListeningPort())
+                .withExposedService(
+                        "uaa",
+                        9081,
+                        Wait.forListeningPort()
+                )
+                .waitingFor("mariadb",
+                            Wait.forLogMessage(".*mysqld: ready for connections.*", 2))
+                .withLogConsumer("credhub", new Slf4jLogConsumer(LOG))
+        CREDHUB_UAA_MARIADB_CONTAINER.start()
+        LOG.info("'mariadb' running at {}:{}",
+                 CREDHUB_UAA_MARIADB_CONTAINER.getServiceHost("mariadb", 3306),
+                 CREDHUB_UAA_MARIADB_CONTAINER.getServicePort("mariadb", 3306))
+        LOG.info("'credhub' running at {}:{}",
+                 CREDHUB_UAA_MARIADB_CONTAINER.getServiceHost("credhub", 9000),
+                 CREDHUB_UAA_MARIADB_CONTAINER.getServicePort("credhub", 9000))
+        LOG.info("'uaa' running at {}:{}",
+                 CREDHUB_UAA_MARIADB_CONTAINER.getServiceHost("uaa", 9081),
+                 CREDHUB_UAA_MARIADB_CONTAINER.getServicePort("uaa", 9081))
+    }
+
+}

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/BoshCredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/BoshCredHubSpec.groovy
@@ -20,8 +20,10 @@ import com.swisscom.cloud.sb.broker.services.bosh.BoshCredHubConfig
 import com.swisscom.cloud.sb.broker.services.bosh.BoshCredHubTemplate
 import com.swisscom.cloud.sb.broker.util.JsonHelper
 import com.swisscom.cloud.sb.broker.util.StringGenerator
+import com.swisscom.cloud.sb.broker.util.test.category.DockerTest
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.StringUtils
+import org.junit.experimental.categories.Category
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean
 import org.springframework.boot.test.context.SpringBootTest
@@ -37,6 +39,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.testcontainers.spock.Testcontainers
 import spock.lang.Shared
 
+@Category([DockerTest.class])
 @ActiveProfiles("credhub")
 @Testcontainers
 @ContextConfiguration

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/BoshCredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/BoshCredHubSpec.groovy
@@ -15,7 +15,6 @@
 
 package com.swisscom.cloud.sb.broker.services.credhub
 
-
 import com.swisscom.cloud.sb.broker.binding.CredHubCredentialStore
 import com.swisscom.cloud.sb.broker.services.bosh.BoshCredHubConfig
 import com.swisscom.cloud.sb.broker.services.bosh.BoshCredHubTemplate
@@ -23,9 +22,6 @@ import com.swisscom.cloud.sb.broker.util.JsonHelper
 import com.swisscom.cloud.sb.broker.util.StringGenerator
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.StringUtils
-import org.junit.ClassRule
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.config.YamlPropertiesFactoryBean
 import org.springframework.boot.test.context.SpringBootTest
@@ -38,12 +34,8 @@ import org.springframework.credhub.support.json.JsonCredential
 import org.springframework.credhub.support.rsa.RsaCredential
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
-import org.testcontainers.containers.DockerComposeContainer
-import org.testcontainers.containers.output.Slf4jLogConsumer
-import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.spock.Testcontainers
 import spock.lang.Shared
-import spock.lang.Specification
 
 @ActiveProfiles("credhub")
 @Testcontainers
@@ -53,29 +45,7 @@ import spock.lang.Specification
         excludeFilters = @ComponentScan.Filter(
                 type = FilterType.ASPECTJ,
                 pattern = "com.swisscom.cloud.sb.broker.util.httpserver.*"))
-class BoshCredHubSpec extends Specification {
-
-    private static final Logger LOG = LoggerFactory.getLogger(CredHubSpec.class)
-
-    @ClassRule
-    public static DockerComposeContainer environment =
-            new DockerComposeContainer(new File("docker/docker-compose-test.yml"))
-                    .withExposedService(
-                            "mariadb",
-                            3306,
-                            Wait.forListeningPort())
-                    .withExposedService(
-                            "credhub",
-                            9000,
-                            Wait.forListeningPort())
-                    .withExposedService(
-                            "uaa",
-                            9081,
-                            Wait.forListeningPort()
-                    )
-                    .waitingFor("mariadb",
-                                Wait.forLogMessage(".*mysqld: ready for connections.*", 2))
-                    .withLogConsumer("credhub", new Slf4jLogConsumer(LOG))
+class BoshCredHubSpec extends AbstractCredHubSpec {
 
     @Autowired
     private BoshCredHubTemplate boshCredHubTemplate
@@ -97,7 +67,6 @@ class BoshCredHubSpec extends Specification {
     CredHubCredentialStore credentialStore
 
     def setupSpec() {
-        environment.start()
         System.setProperty('http.nonProxyHosts', 'localhost|127.0.0.1|uaa.service.cf.internal|credhub.service.consul')
         System.setProperty('javax.net.ssl.keyStore',
                            FileUtils.getFile('src/functional-test/resources/credhub_client.jks').toURI().getPath())
@@ -105,10 +74,6 @@ class BoshCredHubSpec extends Specification {
         System.setProperty('javax.net.ssl.trustStore',
                            FileUtils.getFile('src/functional-test/resources/credhub_client.jks').toURI().getPath())
         System.setProperty('javax.net.ssl.trustStorePassword', 'changeit')
-    }
-
-    def cleanupSpec() {
-        environment.stop()
     }
 
     def setup() {

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
@@ -48,7 +48,6 @@ import spock.lang.Specification
 @ContextConfiguration
 @SpringBootTest(properties = "spring.autoconfigure.exclude=com.swisscom.cloud.sb.broker.util.httpserver.WebSecurityConfig")
 @ComponentScan(
-        basePackages = "com.swisscom.cloud.sb.broker.services.credhub",
         excludeFilters = @ComponentScan.Filter(
                 type = FilterType.ASPECTJ,
                 pattern = "com.swisscom.cloud.sb.broker.util.httpserver.*"))

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
@@ -67,6 +67,11 @@ class CredHubSpec extends Specification {
                             "credhub",
                             9000,
                             Wait.forListeningPort())
+                    .withExposedService(
+                            "uaa",
+                            9081,
+                            Wait.forListeningPort()
+                    )
                     .waitingFor("mariadb",
                                 Wait.forLogMessage(".*mysqld: ready for connections.*", 2))
                     .withLogConsumer("credhub", new Slf4jLogConsumer(LOG))
@@ -102,6 +107,10 @@ class CredHubSpec extends Specification {
         System.setProperty('javax.net.ssl.trustStore',
                            FileUtils.getFile('src/functional-test/resources/credhub_client.jks').toURI().getPath())
         System.setProperty('javax.net.ssl.trustStorePassword', 'changeit')
+    }
+
+    def cleanupSpec() {
+        environment.stop()
     }
 
     def cleanup() {

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.swisscom.cloud.sb.broker.services.credhub
+
+
+import com.swisscom.cloud.sb.broker.util.JsonHelper
+import com.swisscom.cloud.sb.broker.util.StringGenerator
+import org.apache.commons.io.FileUtils
+import org.apache.commons.lang.StringUtils
+import org.junit.ClassRule
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.core.io.ClassPathResource
+import org.springframework.credhub.support.CredentialDetails
+import org.springframework.credhub.support.certificate.CertificateCredential
+import org.springframework.credhub.support.json.JsonCredential
+import org.springframework.credhub.support.permissions.Permission
+import org.springframework.credhub.support.rsa.RsaCredential
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.spock.Testcontainers
+import spock.lang.Shared
+import spock.lang.Specification
+
+@ActiveProfiles("credhub")
+@Testcontainers
+@ContextConfiguration
+@SpringBootTest(properties = "spring.autoconfigure.exclude=com.swisscom.cloud.sb.broker.util.httpserver.WebSecurityConfig")
+@ComponentScan(
+        basePackages = "com.swisscom.cloud.sb.broker.services.credhub",
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASPECTJ,
+                pattern = "com.swisscom.cloud.sb.broker.util.httpserver.*"))
+class CredHubSpec extends Specification {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CredHubSpec.class)
+
+    @ClassRule
+    public static DockerComposeContainer environment =
+            new DockerComposeContainer(new File("docker/docker-compose-test.yml"))
+                    .withExposedService(
+                            "mariadb",
+                            3306,
+                            Wait.forListeningPort())
+                    .withExposedService(
+                            "credhub",
+                            9000,
+                            Wait.forListeningPort())
+                    .waitingFor("mariadb",
+                                Wait.forLogMessage(".*mysqld: ready for connections.*", 2))
+                    .withLogConsumer("credhub", new Slf4jLogConsumer(LOG))
+
+    @Autowired
+    private DefaultCredHubConfig defaultCredHubConfig
+
+    @Shared
+    private String credentialId
+    @Shared
+    private String credentialName
+    @Shared
+    private String appGuid
+
+    private List<String> testCredentialNames
+
+    @Autowired
+    CredHubService credHubService
+
+    def setupSpec() {
+        environment.start()
+        LOG.info("'mariadb' running at {}:{}",
+                 environment.getServiceHost("mariadb", 3306),
+                 environment.getServicePort("mariadb", 3306))
+        LOG.info("'credhub' running at {}:{}",
+                 environment.getServiceHost("credhub", 9000),
+                 environment.getServicePort("credhub", 9000))
+
+        System.setProperty('http.nonProxyHosts', 'localhost|127.0.0.1|uaa.service.cf.internal|credhub.service.consul')
+        System.setProperty('javax.net.ssl.keyStore',
+                           FileUtils.getFile('src/functional-test/resources/credhub_client.jks').toURI().getPath())
+        System.setProperty('javax.net.ssl.keyStorePassword', 'changeit')
+        System.setProperty('javax.net.ssl.trustStore',
+                           FileUtils.getFile('src/functional-test/resources/credhub_client.jks').toURI().getPath())
+        System.setProperty('javax.net.ssl.trustStorePassword', 'changeit')
+    }
+
+    def cleanup() {
+        if (testCredentialNames != null) {
+            for (testCredentialName in testCredentialNames) {
+                credHubService.deleteCredential(testCredentialName)
+            }
+            testCredentialNames = null
+        }
+    }
+
+    def "Write CredHub credential"() {
+        given:
+        credentialName = StringGenerator.randomUuid()
+
+        when:
+        CredentialDetails<JsonCredential> credential = credHubService.writeCredential(credentialName,
+                                                                                      [username                     : StringGenerator.
+                                                                                              randomUuid(), password: StringGenerator.
+                                                                                              randomUuid()])
+        assert credential != null
+        credentialId = credential.id
+
+        then:
+        println('UserCredential: ' + JsonHelper.toJsonString(credential))
+        println('CredentialName: ' + JsonHelper.toJsonString(credential.name))
+        println('UserCredentials value' + JsonHelper.toJsonString(credential.value))
+    }
+
+    def "Get Credential by id"() {
+        given:
+        assert credentialId != null
+
+        when:
+        CredentialDetails<JsonCredential> details = credHubService.getCredential(credentialId)
+
+        then:
+        details != null
+        println('UserCredential: ' + JsonHelper.toJsonString(details))
+        println('CredentialName: ' + JsonHelper.toJsonString(details.name))
+        println('UserCredentials value' + JsonHelper.toJsonString(details.value))
+    }
+
+    def "Add Permission"() {
+        given:
+        assert credentialName != null
+        appGuid = "appGUID"
+
+        when:
+        credHubService.addReadPermission(credentialName, appGuid)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "Get Permissions"() {
+        given:
+        assert credentialName != null
+
+        when:
+        List<Permission> permissions = credHubService.getPermissions(credentialName)
+        Boolean flag = false
+        for (item in permissions) {
+            if (item.actor.primaryIdentifier == appGuid) {
+                flag = true
+                break
+            }
+        }
+
+        then:
+        assert flag
+    }
+
+    def "Delete Permission"() {
+        given:
+        assert credentialName != null
+
+        when:
+        credHubService.deletePermission(credentialName, appGuid)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "Delete Credential by name"() {
+        given:
+        assert credentialId != null
+        String credentialName = credentialName
+
+        when:
+        credHubService.deleteCredential(credentialName)
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "Generate RSA with CredHub"() {
+        given:
+        testCredentialNames = [StringGenerator.randomUuid()]
+
+        when:
+        CredentialDetails<RsaCredential> credential = credHubService.generateRSA(testCredentialNames[0])
+        assert credential != null
+        credentialId = credential.id
+
+        then:
+        println('RsaCredential: ' + JsonHelper.toJsonString(credential))
+    }
+
+    def "Generate CA Certificate with CredHub"() {
+        given:
+        testCredentialNames = [StringGenerator.randomUuid()]
+        defaultCredHubConfig.commonName = "testone.service.consul"
+        defaultCredHubConfig.certificateAuthority = true
+
+        when:
+        CredentialDetails<CertificateCredential> credential = credHubService.generateCertificate(testCredentialNames[0],
+                                                                                                 defaultCredHubConfig)
+        assert credential != null
+        credentialId = credential.id
+
+        then:
+        println('CertificateCredential: ' + JsonHelper.toJsonString(credential))
+    }
+
+    def "Generate Certificate based on generated CA Certificate on CredHub"() {
+        given:
+        testCredentialNames = [StringGenerator.randomUuid(), StringGenerator.randomUuid()]
+        defaultCredHubConfig.commonName = "testone.service.consul"
+        defaultCredHubConfig.certificateAuthority = true
+        CredentialDetails<CertificateCredential> caCredential = credHubService.generateCertificate(testCredentialNames[0],
+                                                                                                   defaultCredHubConfig)
+
+        defaultCredHubConfig.commonName = "testone.service.consul"
+        defaultCredHubConfig.certificateAuthority = false
+        defaultCredHubConfig.certificateAuthorityCredential = '/' + testCredentialNames[0]
+
+        when:
+        CredentialDetails<CertificateCredential> credential = credHubService.generateCertificate(testCredentialNames[1],
+                                                                                                 defaultCredHubConfig)
+
+        assert caCredential != null
+        assert credential != null
+        credentialId = credential.id
+
+        then:
+        println('CertificateCredential: ' + JsonHelper.toJsonString(credential))
+    }
+
+    static boolean checkCredHubConfigSet() {
+        YamlPropertiesFactoryBean yaml = new YamlPropertiesFactoryBean()
+        yaml.setResources(new ClassPathResource("application-test.yml"))
+        yaml.afterPropertiesSet()
+        return StringUtils.equals(yaml.object.getProperty("osb.credhub.enable"), "true")
+    }
+
+}

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubSpec.groovy
@@ -17,8 +17,10 @@ package com.swisscom.cloud.sb.broker.services.credhub
 
 import com.swisscom.cloud.sb.broker.util.JsonHelper
 import com.swisscom.cloud.sb.broker.util.StringGenerator
+import com.swisscom.cloud.sb.broker.util.test.category.DockerTest
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang.StringUtils
+import org.junit.experimental.categories.Category
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -36,8 +38,8 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.testcontainers.spock.Testcontainers
 import spock.lang.Shared
-import spock.lang.Specification
 
+@Category([DockerTest.class])
 @ActiveProfiles("credhub")
 @Testcontainers
 @ContextConfiguration

--- a/broker/src/test/resources/application-credhub.yml
+++ b/broker/src/test/resources/application-credhub.yml
@@ -1,6 +1,6 @@
 ---
 spring:
-  profiles: test
+  profiles: credhub
 
   datasource:
     driverClassName: com.mysql.cj.jdbc.Driver
@@ -29,14 +29,33 @@ spring:
           uaa:
             token-uri: http://localhost:8081/uaa/oauth/token
 
+management:
+  metrics:
+    export:
+      influx:
+        enabled: false
+        uri: http://localhost:8086
+        step: 60s
+        userName:
+        db: osb_metrics
+        env: "local"
+    enable:
+      jvm: false
+      dataSource: false
+      process: false
+      system: false
+      http: false
+      logback: false
+
+
 # Sets the Credential Store to a CredHub instance
 osb:
   credential:
-    store: "default"
+    store: "credhub"
 
-#com.swisscom.cloud.sb.broker.bosh.credhub:
-#  url: https://localhost:9000
-#  oauth2.registration-id: bosh-client
+com.swisscom.cloud.sb.broker.bosh.credhub:
+  url: https://localhost:9000
+  oauth2.registration-id: bosh-client
 
 com.swisscom.cloud.sb.broker.serviceDefinitions: [
 {

--- a/broker/src/test/resources/application-credhub.yml
+++ b/broker/src/test/resources/application-credhub.yml
@@ -1,6 +1,11 @@
 ---
+debug: true
 spring:
   profiles: credhub
+
+  jpa:
+    hibernate:
+      use-new-id-generator-mappings: false
 
   datasource:
     driverClassName: com.mysql.cj.jdbc.Driver
@@ -27,7 +32,7 @@ spring:
             authorization-grant-type: client_credentials
         provider:
           uaa:
-            token-uri: http://localhost:8081/uaa/oauth/token
+            token-uri: http://localhost:9081/uaa/oauth/token
 
 management:
   metrics:
@@ -53,9 +58,37 @@ osb:
   credential:
     store: "credhub"
 
+# Credhub Certificate parameters
+com.swisscom.cloud.sb.broker.credhub:
+  url: https://localhost:9000
+  oauth2.registration-id: credhub-client
+  keyLength: LENGTH_2048
+  commonName:
+  organization: ServiceBroker
+  organizationUnit: SB
+  locality: Bern
+  state: Bern
+  country: CH
+  duration: 365
+  certificateAuthority: false
+  certificateAuthorityCredential:
+  selfSign: false
+
 com.swisscom.cloud.sb.broker.bosh.credhub:
   url: https://localhost:9000
   oauth2.registration-id: bosh-client
+  keyLength: LENGTH_2048
+  commonName:
+  organization: ServiceBroker
+  organizationUnit: SB
+  locality: Bern
+  state: Bern
+  country: CH
+  duration: 365
+  certificateAuthority: false
+  certificateAuthorityCredential:
+  selfSign: false
+
 
 com.swisscom.cloud.sb.broker.serviceDefinitions: [
 {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     apply plugin: 'groovy'
     apply from: "$rootDir/gradle/repositories.gradle"
     apply from: "$rootDir/gradle/dependencies.gradle"
-    apply from: "$rootDir/gradle/functional-testing.gradle"
+    apply from: "$rootDir/gradle/testing.gradle"
     apply from: "$rootDir/gradle/publishing.gradle"
 
     group = 'com.swisscom.cloud.sb'

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,8 +39,9 @@ ext {
             javax_el                           : '3.0.0',
 
             junit                              : '4.12',             // Unit Testing
-            spock                              : '1.2-groovy-2.5',   // THE testing framework
+            spock                              : '1.3-groovy-2.5',   // THE testing framework
             cglib                              : '3.2.7',            // For mocking classes without default constructor
+            test_containers                    : '1.11.2',            // Running docker from tests
 
     ]
     libs = [
@@ -113,7 +114,9 @@ ext {
             spock_spring                                   : "org.spockframework:spock-spring:${versions.spock}",
             cglib                                          : "cglib:cglib-nodep:${versions.cglib}",
             groovy_test                                    : "org.codehaus.groovy:groovy-test:${versions.groovy}",
-            spring_boot_starter_test                       : "org.springframework.boot:spring-boot-starter-test:${versions.spring_boot}"
+            spring_boot_starter_test                       : "org.springframework.boot:spring-boot-starter-test:${versions.spring_boot}",
+            test_containers                                : "org.testcontainers:testcontainers:${versions.test_containers}",
+            test_containers_spock                          : "org.testcontainers:spock:${versions.test_containers}"
 
     ]
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -39,7 +39,7 @@ ext {
             javax_el                           : '3.0.0',
 
             junit                              : '4.12',             // Unit Testing
-            spock                              : '1.3-groovy-2.5',   // THE testing framework
+            spock                              : '1.2-groovy-2.5',   // THE testing framework
             cglib                              : '3.2.7',            // For mocking classes without default constructor
             test_containers                    : '1.11.2',            // Running docker from tests
 

--- a/gradle/repositories.gradle
+++ b/gradle/repositories.gradle
@@ -15,8 +15,8 @@
 
 repositories {
     mavenLocal()
-    jcenter()
     mavenCentral()
+    jcenter()
     maven {
         url "https://oss.sonatype.org/content/repositories/releases"
     }

--- a/gradle/testing.gradle
+++ b/gradle/testing.gradle
@@ -16,17 +16,35 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+test {
+    useJUnit {
+        excludeCategories 'com.swisscom.cloud.sb.broker.util.test.category.IntegrationTest'
+    }
+}
+
+task it(type: Test) {
+    useJUnit {
+        includeCategories 'com.swisscom.cloud.sb.broker.util.test.category.IntegrationTest'
+    }
+}
+
+
+
 // Add integration/functional test source sets
 sourceSets {
-    integrationTest { sourceSet ->
+    integrationTest {sourceSet ->
         ["java", "kotlin", "groovy", "scala", "resources"].each {
-            if (!sourceSet.hasProperty(it)) return
+            if (!sourceSet.hasProperty(it)) {
+                return
+            }
             sourceSet."$it".srcDir file("src/integration-test/${it}")
         }
     }
-    functionalTest { sourceSet ->
+    functionalTest {sourceSet ->
         ["java", "kotlin", "groovy", "scala", "resources"].each {
-            if (!sourceSet.hasProperty(it)) return
+            if (!sourceSet.hasProperty(it)) {
+                return
+            }
             sourceSet."$it".srcDir file("src/functional-test/${it}")
         }
     }
@@ -71,9 +89,9 @@ tasks.withType(Test) {
     testLogging {
         // set options for log level LIFECYCLE
         events TestLogEvent.FAILED,
-                TestLogEvent.PASSED,
-                TestLogEvent.SKIPPED,
-                TestLogEvent.STANDARD_OUT
+               TestLogEvent.PASSED,
+               TestLogEvent.SKIPPED,
+               TestLogEvent.STANDARD_OUT
         exceptionFormat TestExceptionFormat.FULL
         showExceptions false
         showCauses true
@@ -82,17 +100,17 @@ tasks.withType(Test) {
         // set options for log level DEBUG and INFO
         debug {
             events TestLogEvent.STARTED,
-                    TestLogEvent.FAILED,
-                    TestLogEvent.PASSED,
-                    TestLogEvent.SKIPPED,
-                    TestLogEvent.STANDARD_ERROR,
-                    TestLogEvent.STANDARD_OUT
+                   TestLogEvent.FAILED,
+                   TestLogEvent.PASSED,
+                   TestLogEvent.SKIPPED,
+                   TestLogEvent.STANDARD_ERROR,
+                   TestLogEvent.STANDARD_OUT
             exceptionFormat TestExceptionFormat.FULL
         }
         info.events = debug.events
         info.exceptionFormat = debug.exceptionFormat
 
-        afterSuite { desc, result ->
+        afterSuite {desc, result ->
             if (!desc.parent) { // will match the outermost suite
                 def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
                 def startItem = '[', endItem = ']'

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/category/DockerTest.java
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/category/DockerTest.java
@@ -1,0 +1,8 @@
+package com.swisscom.cloud.sb.broker.util.test.category;
+
+/**
+ * Marker interface for all those {@link IntegrationTest} which use
+ * <a href='https://www.testcontainers.org'>Test Containers</a> for setting up services for the test
+ */
+public interface DockerTest extends IntegrationTest {
+}

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/category/IntegrationTest.java
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/category/IntegrationTest.java
@@ -1,0 +1,8 @@
+package com.swisscom.cloud.sb.broker.util.test.category;
+
+/**
+ * Marker interface for our integration tests to be used as
+ * <a href='https://github.com/junit-team/junit4/wiki/categories'>JUnit Category</a>
+ */
+public interface IntegrationTest {
+}


### PR DESCRIPTION
We started using [Test Containers](https://www.testcontainers.org/) for launching a docker compose instance automatically when integration testing. Using [Junit Category]() we can differentiate the tests between unit and integration test.