### PR TITLE
Deprecate service-definition API

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,12 @@ serviceDefinitions:
       displayName: 'Small'
 ```
 
+
+
 Updating/Creating Service Definitions over the service-definition API (defined below) requires the JSON format like following example.
+
+> **DEPRECATED**: The service-definition API is deprecated and will be removed in future releases
+
 ```json
 {
     "guid": "udn9276f-hod4-5432-vw34-6c33d7359c12",
@@ -228,6 +233,7 @@ Updating/Creating Service Definitions over the service-definition API (defined b
 
 **_Following endpoints are deprecated_**
 ### Get service definition
+> **DEPRECATED**: The service-definition API is deprecated and will be removed in future releases
 
 Via the example call below, service definitions for a given service id can be retrieved.
 
@@ -236,6 +242,7 @@ curl -u 'username:password' -X GET 'http://localhost:8080/custom/admin/service-d
 ```
 
 ### Add service definition
+> **DEPRECATED**: The service-definition API is deprecated and will be removed in future releases
 
 Service Broker provides a way to update service definitions via HTTP calls.
 
@@ -248,6 +255,7 @@ curl -u 'username:password' -X POST -H 'Content-Type: application/json' --data-b
 This interface can be used for both adding a new service or updating an existing one. For an existing service, if a plan that is in use is tried to be removed an exception will be thrown.
 
 ### Remove service definition
+> **DEPRECATED**: The service-definition API is deprecated and will be removed in future releases
 
 A service and its plan(s), which are not used i.e. which have no service instances, can be removed via a REST interface.
 Here is an example for how to delete a service that has the id `service_id`:

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ServiceDefinitionController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ServiceDefinitionController.groovy
@@ -31,10 +31,16 @@ import io.swagger.annotations.ApiOperation
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.*
 
+/**
+ * Any modification of the service definition during runtime is considered dangerous, as the  ServiceDefinitionInitializer
+ * overwrites service definitions on startup.
+ */
+
 @Api(value = "Service definition", description = "Endpoint for service definition")
 @RestController
 @CompileStatic
 @Slf4j
+@Deprecated
 class ServiceDefinitionController extends BaseController {
     @VisibleForTesting
     @Autowired

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/servicedefinition/ServiceDefinitionProcessor.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/servicedefinition/ServiceDefinitionProcessor.groovy
@@ -69,6 +69,7 @@ class ServiceDefinitionProcessor {
     @Autowired
     private List<PlanBasedMetricsService> planBasedMetricServices
 
+    @Deprecated
     def createOrUpdateServiceDefinition(String content) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(content), "Service Definition can't be empty")
         // Preconditions.checkArgument() // TODO: check content type is application/json
@@ -95,6 +96,7 @@ class ServiceDefinitionProcessor {
         processPlans(service, serviceDto)
     }
 
+    @Deprecated
     def deleteServiceDefinition(String id) {
         CFService service = cfServiceRepository.findByGuid(id)
         if (!service) {
@@ -113,6 +115,7 @@ class ServiceDefinitionProcessor {
         cfServiceRepository.flush()
     }
 
+    @Deprecated
     ServiceDto getServiceDefinition(String id) {
         CFService service = cfServiceRepository.findByGuid(id)
         if (!service) {


### PR DESCRIPTION
Due to the behaviour of the [ServiceDefinitionInitializer](https://github.com/swisscom/open-service-broker/blob/develop/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/servicedefinition/ServiceDefinitionInitializer.groovy#L77) the API
endpoints for service-definition must be deprecated, as any changes done
at runtime will be disabled or deleted on a restart.