### PR TITLE
bugfix: Do not use BoshFacade as component

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -32,13 +32,11 @@ import com.swisscom.cloud.sb.broker.util.servicedetail.ServiceDetailsHelper
 import groovy.transform.CompileStatic
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.stereotype.Component
 import org.springframework.util.Assert
 
 import static com.swisscom.cloud.sb.broker.services.bosh.BoshServiceDetailKey.*
 import static com.swisscom.cloud.sb.broker.services.bosh.resources.BoshConfigRequest.boshConfigRequest
 
-@Component
 @CompileStatic
 class BoshFacade {
     private static final Logger LOG = LoggerFactory.getLogger(BoshFacade.class);


### PR DESCRIPTION
Using BoshFacade with @Component is problematic, as multiple service
configs can implement BoshBasedServiceConfig and a resolution like
@Primary would need to be defined (which makes not much sense).
Furthermore BoshFacade can be instantiated with static create method,
when needed.