### PR TITLE
bug: StateMachineBasedServiceProvider constructor missing

### DIFF
--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/statemachine/DummyAsyncServiceConfig.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/statemachine/DummyAsyncServiceConfig.groovy
@@ -1,0 +1,10 @@
+package com.swisscom.cloud.sb.broker.services.statemachine
+
+import com.swisscom.cloud.sb.broker.services.AsyncServiceConfig
+import org.springframework.stereotype.Component
+
+@Component
+class DummyAsyncServiceConfig implements AsyncServiceConfig {
+    List<String> ipRanges
+    List<String> protocols
+}

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/statemachine/DummyStateMachineBasedServiceProvider.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/statemachine/DummyStateMachineBasedServiceProvider.groovy
@@ -1,0 +1,51 @@
+package com.swisscom.cloud.sb.broker.services.statemachine
+
+import com.swisscom.cloud.sb.broker.async.AsyncProvisioningService
+import com.swisscom.cloud.sb.broker.binding.BindRequest
+import com.swisscom.cloud.sb.broker.binding.BindResponse
+import com.swisscom.cloud.sb.broker.binding.UnbindRequest
+import com.swisscom.cloud.sb.broker.provisioning.ProvisioningPersistenceService
+import com.swisscom.cloud.sb.broker.provisioning.lastoperation.LastOperationJobContext
+import com.swisscom.cloud.sb.broker.provisioning.statemachine.StateMachine
+import com.swisscom.cloud.sb.broker.provisioning.statemachine.StateMachineBasedServiceProvider
+import com.swisscom.cloud.sb.broker.provisioning.statemachine.StateMachineContext
+import org.springframework.stereotype.Component
+
+@Component
+class DummyStateMachineBasedServiceProvider extends StateMachineBasedServiceProvider<DummyAsyncServiceConfig> {
+    DummyStateMachineBasedServiceProvider(AsyncProvisioningService asyncProvisioningService,
+                                          ProvisioningPersistenceService provisioningPersistenceService,
+                                          DummyAsyncServiceConfig serviceConfig) {
+        super(asyncProvisioningService, provisioningPersistenceService, serviceConfig)
+    }
+
+    @Override
+    protected StateMachine getProvisionStateMachine(LastOperationJobContext lastOperationJobContext) {
+        return null
+    }
+
+    @Override
+    protected StateMachine getDeprovisionStateMachine(LastOperationJobContext lastOperationJobContext) {
+        return null
+    }
+
+    @Override
+    protected StateMachine getUpdateStateMachine(LastOperationJobContext lastOperationJobContext) {
+        return null
+    }
+
+    @Override
+    protected StateMachineContext createStateMachineContext(LastOperationJobContext lastOperationJobContext) {
+        return null
+    }
+
+    @Override
+    BindResponse bind(BindRequest request) {
+        return null
+    }
+
+    @Override
+    void unbind(UnbindRequest request) {
+
+    }
+}

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/statemachine/StateMachineBasedServiceProviderTest.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/services/statemachine/StateMachineBasedServiceProviderTest.groovy
@@ -1,0 +1,30 @@
+package com.swisscom.cloud.sb.broker.services.statemachine
+
+import com.swisscom.cloud.sb.broker.provisioning.statemachine.StateMachineBasedServiceProvider
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+
+@ContextConfiguration
+@SpringBootTest(properties = "spring.autoconfigure.exclude=com.swisscom.cloud.sb.broker.util.httpserver.WebSecurityConfig")
+@ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.ASPECTJ, pattern = "com.swisscom.cloud.sb.broker.util.httpserver.*"))
+class StateMachineBasedServiceProviderTest extends Specification {
+    private static final Logger LOG = LoggerFactory.getLogger(StateMachineBasedServiceProvider.class);
+
+    @Autowired
+    DummyStateMachineBasedServiceProvider sut
+
+    def "service provider bean could be found"() {
+        when:
+        LOG.info("HelloWorldStateMachineBasedServiceProvider bean should be loaded")
+
+        then:
+        sut != null
+        sut instanceof DummyStateMachineBasedServiceProvider
+    }
+}


### PR DESCRIPTION
Due to the inheritance used with StatemachineBasedServiceProvider and
the changes made to [AsyncServiceProvider](https://github.com/swisscom/open-service-broker/blob/develop/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/AsyncServiceProvider.groovy#L51), a corresponding constructor needs to be defined.