### PR TITLE
chore: lock /var/lib/apt/lists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       SPRING_PROFILES_ACTIVE: info,default,extensions,secrets,test
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      - run: sudo killall -9 apt-get || true && sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
       - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
       - run: pushd docker && ./setup_docker.sh ; popd
       - run: ./gradlew clean build -x test -x functionalTest --stacktrace
@@ -42,7 +42,7 @@ jobs:
       SPRING_PROFILES_ACTIVE: info,default,extensions,secrets,test
     steps:
       - checkout
-      - run: sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+      - run: sudo killall -9 apt-get || true && sudo apt-get update && sudo apt-get install openjdk-8-jdk && sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
       - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
       - run: pushd docker && ./setup_docker.sh ; popd
       - run: ./gradlew clean build -x test -x integrationTest --stacktrace


### PR DESCRIPTION
On CircleCI we get the error `Could not get lock /var/lib/apt/lists/lock` for an unknown reason. The fix implemented here has been proposed in the discussion [here](https://discuss.circleci.com/t/could-not-get-lock-var-lib-apt-lists-lock/28337).
