### PR TITLE
bug: wrong update status code

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
@@ -73,7 +73,7 @@ class UpdatingController extends BaseController {
                     createUpdateRequest(serviceInstance, updateDto, acceptsIncomplete),
                     acceptsIncomplete)
 
-            return new ResponseEntity<UpdateResponseDto>(new UpdateResponseDto(), updatingResponse.isAsync ? HttpStatus.ACCEPTED : HttpStatus.CREATED)
+            return new ResponseEntity<UpdateResponseDto>(new UpdateResponseDto(), updatingResponse.isAsync ? HttpStatus.ACCEPTED : HttpStatus.OK)
         } catch (Exception ex) {
             failed = true
             throw ex

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/ServiceUpdateFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/ServiceUpdateFunctionalSpec.groovy
@@ -309,7 +309,7 @@ class ServiceUpdateFunctionalSpec extends BaseFunctionalSpec {
         def response = serviceLifeCycler.requestUpdateServiceInstance(serviceInstanceGuid, defaultServiceGuid, secondPlanGuid)
 
         then:
-        response.statusCode == HttpStatus.CREATED
+        response.statusCode == HttpStatus.OK
         response.body.operation == null
 
         cleanup:


### PR DESCRIPTION
For synchronous service update success only status codes 200 and 202 are accepted. Currently we are returning 201 which the platform has to interpret as failure, [see spec](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#response-3).