### PR TITLE
bug: inject OpsManagerFacade for @Retryable

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProvider.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProvider.groovy
@@ -76,9 +76,10 @@ class MongoDbEnterpriseServiceProvider
     MongoDbEnterpriseServiceProvider(AsyncProvisioningService asyncProvisioningService,
                                      ProvisioningPersistenceService provisioningPersistenceService,
                                      MongoDbEnterpriseConfig serviceConfig,
-                                     MongoDbEnterpriseFreePortFinder mongoDbEnterpriseFreePortFinder) {
+                                     MongoDbEnterpriseFreePortFinder mongoDbEnterpriseFreePortFinder,
+                                     OpsManagerFacade opsManagerFacade) {
         super(asyncProvisioningService, provisioningPersistenceService, serviceConfig)
-        this.opsManagerFacade = new OpsManagerFacade(serviceConfig)
+        this.opsManagerFacade = opsManagerFacade
         this.mongoDbEnterpriseFreePortFinder = mongoDbEnterpriseFreePortFinder
     }
 
@@ -245,11 +246,11 @@ class MongoDbEnterpriseServiceProvider
         return new BindResponse(details: [from(ServiceDetailKey.USER, dbUserCredentials.username),
                                           from(ServiceDetailKey.PASSWORD, dbUserCredentials.password),
                                           from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_OPS_MANAGER_USER_NAME,
-                                                             opsManagerCredentials.user),
+                                               opsManagerCredentials.user),
                                           from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_OPS_MANAGER_PASSWORD,
-                                                             opsManagerCredentials.password),
+                                               opsManagerCredentials.password),
                                           from(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_OPS_MANAGER_USER_ID,
-                                                             opsManagerCredentials.userId)],
+                                               opsManagerCredentials.userId)],
                                 credentials: new MongoDbEnterpriseBindResponseDto(
                                         database: database,
                                         username: dbUserCredentials.username,

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/opsmanager/OpsManagerFacade.groovy
@@ -176,6 +176,7 @@ class OpsManagerFacade {
         throw new NotImplementedException()
     }
 
+    // TODO: Replace retryable with systematic usage of resilience4j
     @Retryable(
             value = MongoDBAutomationConfigUpdateNotCompletedException.class,
             maxAttempts = 10,

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProviderSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/MongoDbEnterpriseServiceProviderSpec.groovy
@@ -68,7 +68,8 @@ class MongoDbEnterpriseServiceProviderSpec extends Specification {
         serviceProvider = new MongoDbEnterpriseServiceProvider(Mock(AsyncProvisioningService),
                                                                Mock(ProvisioningPersistenceService),
                                                                mongoDbEnterpriseConfig,
-                                                               Mock(MongoDbEnterpriseFreePortFinder))
+                                                               Mock(MongoDbEnterpriseFreePortFinder),
+                                                               mockedOpsManagerFacade)
     }
 
     def "synchronous provisioning requests are not allowed"() {


### PR DESCRIPTION
Since OpsManagerFacade is using @Retryable for the method
`checkAndRetryForOnGoingChanges()` it has to be injected by Spring to
`MongoDbEnterpriseServiceProvider`, so that the annotation is interpreted.