### PR TITLE
bug: no failure on bosh error state

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -180,7 +180,7 @@ class BoshFacade {
         if (task.state == null) {
             throw new RuntimeException("Unknown bosh task state: ${task.toString()}")
         }
-        if ([Task.State.cancelled, Task.State.cancelling, Task.State.errored].contains(task.state)) {
+        if ([Task.State.cancelled, Task.State.cancelling, Task.State.errored, Task.State.error].contains(task.state)) {
             throw new RuntimeException("Task failed: ${task.toString()}")
         }
         return Task.State.done == task.state

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -180,7 +180,7 @@ class BoshFacade {
         if (task.state == null) {
             throw new RuntimeException("Unknown bosh task state: ${task.toString()}")
         }
-        if ([Task.State.cancelled, Task.State.cancelling, Task.State.errored, Task.State.error].contains(task.state)) {
+        if ([Task.State.cancelled, Task.State.cancelling, Task.State.errored, Task.State.error, Task.State.timeout].contains(task.state)) {
             throw new RuntimeException("Task failed: ${task.toString()}")
         }
         return Task.State.done == task.state

--- a/broker/core/src/main/java/com/swisscom/cloud/sb/broker/services/bosh/resources/Task.java
+++ b/broker/core/src/main/java/com/swisscom/cloud/sb/broker/services/bosh/resources/Task.java
@@ -24,6 +24,6 @@ public interface Task {
     String getUser();
 
     enum State {
-        queued, processing, cancelled, cancelling, done, errored, error
+        queued, processing, cancelled, cancelling, done, errored, error, timeout
     }
 }


### PR DESCRIPTION
Bosh director REST API returns `state: error` rather than `state: errored` which is not recognized as failure from `BoshFacade` when checking whether task is successful.

Links:
[Bosh Director HTTP API doc](https://bosh.io/docs/director-api-v1/#tasks)