### PR TITLE
Add new OpsManager roles to DTO

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/access/OpsManagerUserDto.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/dto/access/OpsManagerUserDto.groovy
@@ -35,6 +35,8 @@ class OpsManagerUserDto implements Serializable {
         GROUP_BACKUP_ADMIN,
         GROUP_MONITORING_ADMIN,
         GROUP_DATA_ACCESS_ADMIN,
+        GROUP_DATA_ACCESS_READ_ONLY,
+        GROUP_DATA_ACCESS_READ_WRITE,
         GROUP_OWNER,
         GROUP_READ_ONLY,
         GROUP_USER_ADMIN

--- a/broker/src/main/resources/application-broker.yml
+++ b/broker/src/main/resources/application-broker.yml
@@ -54,7 +54,7 @@ com.swisscom.cloud.sb.broker.service.mongodbent:
   opsManagerUrlForAutomationAgent: '' #This parameter is optional
   opsManagerUser:
   opsManagerApiKey:
-#  opsManagerUserRoles: 'GROUP_MONITORING_ADMIN,GROUP_DATA_ACCESS_ADMIN'
+  opsManagerUserRoles: 'GROUP_MONITORING_ADMIN,GROUP_DATA_ACCESS_READ_ONLY'
   portRange: '27000-40000'
   dbFolder: '/var/vcap/store/mongodb-data'
   libFolder: '/var/vcap/store/mongodb-mms-automation'


### PR DESCRIPTION
This PR updates the OpsManager DTO with the recently added DATA_ACCESS roles.
Additionally it adds the role 'GROUP_DATA_ACCESS_READ_ONLY' to the default configured roles.