### PR TITLE
chore: properly merge for correct tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ client: [ ![client Download](https://api.bintray.com/packages/swisscom/open-serv
 
 ## Introduction
 
-Open Service Broker is an implementation of the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/blob/v2.11/spec.md). It enables platforms such as [Cloud Foundry](https://www.cloudfoundry.org/) & [Kubernetes](https://kubernetes.io/) to provision and manage services.
+Open Service Broker is an implementation of the [Open Service Broker API](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md). It enables platforms such as [Cloud Foundry](https://www.cloudfoundry.org/) & [Kubernetes](https://kubernetes.io/) to provision and manage services.
 
 Open Service Broker is built in a modular way and one service broker can host multiple services.
 


### PR DESCRIPTION
For proper tagging we decided to use merging rather than rebasing. Unfortunately some PRs were rebased rather than merged. We now forbid rebasing in GitHub repository configuration and release the missed PRs with this PR.