### PR TITLE
fix: remove duplicate plans name

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/CFServiceDtoConverter.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/CFServiceDtoConverter.groovy
@@ -39,7 +39,7 @@ class CFServiceDtoConverter extends AbstractGenericConverter<CFService, CFServic
         prototype.name = source.name
         prototype.description = source.description
         prototype.metadata = convertMetadata(source)
-        prototype.plans = planDtoConverter.convertAll(source.plans.sort { it.displayIndex })
+        prototype.cfPlans = planDtoConverter.convertAll(source.plans.sort { it.displayIndex })
         prototype.tags = source.tags.collect { Tag t -> t.tag }
         prototype.requires = source.permissions.collect { CFServicePermission p -> p.permission }
         prototype.dashboard_client = dashboardClientDtoConverter.convert(source)

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/PlanDtoConverter.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/PlanDtoConverter.groovy
@@ -15,7 +15,7 @@
 
 package com.swisscom.cloud.sb.broker.cfapi.converter
 
-import com.swisscom.cloud.sb.broker.cfapi.dto.PlanDto
+import com.swisscom.cloud.sb.broker.cfapi.dto.CFPlanDto
 import com.swisscom.cloud.sb.broker.cfapi.dto.SchemasDto
 import com.swisscom.cloud.sb.broker.converter.AbstractGenericConverter
 import com.swisscom.cloud.sb.broker.model.Plan
@@ -26,10 +26,10 @@ import static MetadataJsonHelper.getValue
 
 @Component
 @CompileStatic
-class PlanDtoConverter extends AbstractGenericConverter<Plan, PlanDto> {
+class PlanDtoConverter extends AbstractGenericConverter<Plan, CFPlanDto> {
 
     @Override
-    void convert(Plan source, PlanDto prototype) {
+    void convert(Plan source, CFPlanDto prototype) {
         prototype.id = source.guid
         prototype.name = source.name
         prototype.active = source.active

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/PlanDtoConverterSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cfapi/converter/PlanDtoConverterSpec.groovy
@@ -15,7 +15,7 @@
 
 package com.swisscom.cloud.sb.broker.cfapi.converter
 
-import com.swisscom.cloud.sb.broker.cfapi.dto.PlanDto
+import com.swisscom.cloud.sb.broker.cfapi.dto.CFPlanDto
 import com.swisscom.cloud.sb.broker.model.Plan
 import com.swisscom.cloud.sb.broker.model.PlanMetadata
 import spock.lang.Specification
@@ -47,7 +47,7 @@ class PlanDtoConverterSpec extends Specification {
         def planDtoConverter = new PlanDtoConverter()
         def plan = new Plan(metadata: [new PlanMetadata(key: "key1", value: value, type: type)])
         when:
-        PlanDto planMetadataDto = planDtoConverter.convert(plan)
+        CFPlanDto planMetadataDto = planDtoConverter.convert(plan)
         then:
         planMetadataDto.metadata.get('key1') == result
         where:

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/dto/CFPlanDto.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/dto/CFPlanDto.groovy
@@ -20,7 +20,7 @@ import com.swisscom.cloud.sb.broker.servicedefinition.dto.ParameterDto
 import groovy.transform.CompileStatic
 
 @CompileStatic
-class PlanDto {
+class CFPlanDto {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String id
     String name

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/dto/CFServiceDto.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/cfapi/dto/CFServiceDto.groovy
@@ -16,6 +16,7 @@
 package com.swisscom.cloud.sb.broker.cfapi.dto
 
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import groovy.transform.CompileStatic
 
 @CompileStatic
@@ -26,7 +27,8 @@ class CFServiceDto implements Serializable {
     String description
     boolean bindable
     boolean active = true
-    List<PlanDto> plans
+    @JsonProperty("plans")
+    List<CFPlanDto> cfPlans
     List<String> tags
     List<String> requires
     Map<String, Object> metadata = new HashMap<String, Object>()

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/servicedefinition/dto/PlanDto.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/servicedefinition/dto/PlanDto.groovy
@@ -15,10 +15,11 @@
 
 package com.swisscom.cloud.sb.broker.servicedefinition.dto
 
+import com.swisscom.cloud.sb.broker.cfapi.dto.CFPlanDto
 import groovy.transform.CompileStatic
 
 @CompileStatic
-class PlanDto extends com.swisscom.cloud.sb.broker.cfapi.dto.PlanDto {
+class PlanDto extends CFPlanDto {
     String guid
     String templateId
     String templateVersion


### PR DESCRIPTION
`ServiceDto` and `CFServiceDto` both have the field `plans` which is
 problematic, because `ServiceDto` extends `CFServiceDto`. Furthermore
 `PlanDto` classname is duplicated whereby `PlanDto` extends from `PlanDto`