### PR TITLE
bug: Improve the BOSH variables replacement

### DIFF
--- a/broker/core/bosh-service/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplate.groovy
+++ b/broker/core/bosh-service/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplate.groovy
@@ -22,6 +22,8 @@ import org.yaml.snakeyaml.Yaml
 import java.util.regex.Pattern
 
 class BoshTemplate {
+    private static final String BOSH_TEMPLATE_REGEX_FOR_VARIABLES = "\"\\{\\{VARIABLE}}\"|\\{\\{VARIABLE}}";
+
     public static final String REGEX_PLACEHOLDER_PREFIX = '\\{\\{'
     public static final String REGEX_PLACEHOLDER_POSTFIX = '\\}\\}'
     public static final Pattern anyPlaceHolder = createPattern('.*')
@@ -47,9 +49,23 @@ class BoshTemplate {
         return new BoshTemplate(template)
     }
 
+    /**
+     * @deprecated Use{@link BoshTemplate#replaceAllNamed(java.lang.String, java.lang.String)}
+     * @param key
+     * @param value
+     */
+    @Deprecated
     void replace(String key, String value) {
         processed = processed.replaceAll(createPatternWithQuotes(key), value)
         processed = processed.replaceAll(createPattern(key), value)
+    }
+
+    void replaceAllNamed(String boshVariableName, String replacement) {
+        replaceAll(BOSH_TEMPLATE_REGEX_FOR_VARIABLES.replaceAll("VARIABLE", boshVariableName), replacement)
+    }
+
+    void replaceAll(String regularExpression, String replacement) {
+        processed = processed.replaceAll(regularExpression, replacement)
     }
 
     String build() {

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplateSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshTemplateSpec.groovy
@@ -96,6 +96,72 @@ class BoshTemplateSpec extends Specification {
         output == expected
     }
 
+    def "should replace all placeholders"() {
+        given:
+
+        def input = """ director_uuid: BOSH_UID #STACK LEVEL
+                        name: {{prefix}}-{{guid}} #SERVICE-INSTANCE LEVEL  e.g. <serviceid>
+                        instance_groups:
+                        - azs:
+                          - z1
+                          instances: 3
+                          jobs:
+                          - name: redis
+                            properties:
+                              redis-server:
+                                databases: "{{databases}}_test" #SERVICE-INSTANCE LEVEL
+                                instances: 3
+                                master-name: {{guid}} #SERVICE-INSTANCE LEVEL
+                                maxclients: "{{maxclients}}" #SERVICE-INSTANCE LEVEL
+                                port: "{{redis-server-port}}" #SERVICE-INSTANCE LEVEL
+                                security:
+                                  require_pass: {{password}} #SERVICE-TEMPLATE LEVEL
+                                sentinel-port: {{redis-sentinel-port}} #SERVICE-INSTANCE LEVEL
+                                service-name: {{guid}} #SERVICE-INSTANCE LEVEL
+                                timeout: 10
+                                config-command: {{config-command}} #SERVICE-INSTANCE LEVEL
+                                slaveof-command: {{slaveof-command}} #SERVICE-INSTANCE LEVEL"""
+        def expected = """ director_uuid: BOSH_UID #STACK LEVEL
+                        name: prefix-guid #SERVICE-INSTANCE LEVEL  e.g. <serviceid>
+                        instance_groups:
+                        - azs:
+                          - z1
+                          instances: 3
+                          jobs:
+                          - name: redis
+                            properties:
+                              redis-server:
+                                databases: "databases_test" #SERVICE-INSTANCE LEVEL
+                                instances: 3
+                                master-name: guid #SERVICE-INSTANCE LEVEL
+                                maxclients: maxclients #SERVICE-INSTANCE LEVEL
+                                port: redis-server-port #SERVICE-INSTANCE LEVEL
+                                security:
+                                  require_pass: password #SERVICE-TEMPLATE LEVEL
+                                sentinel-port: redis-sentinel-port #SERVICE-INSTANCE LEVEL
+                                service-name: guid #SERVICE-INSTANCE LEVEL
+                                timeout: 10
+                                config-command: config-command #SERVICE-INSTANCE LEVEL
+                                slaveof-command: slaveof-command #SERVICE-INSTANCE LEVEL"""
+        BoshTemplate template = new BoshTemplate(input)
+        and:
+        template.replaceAllNamed('prefix', 'prefix')
+        template.replaceAllNamed('guid', 'guid')
+        template.replaceAllNamed('databases', 'databases')
+        template.replaceAllNamed('maxclients', 'maxclients')
+        template.replaceAllNamed('redis-server-port', 'redis-server-port')
+        template.replaceAllNamed('password', 'password')
+        template.replaceAllNamed('redis-sentinel-port', 'redis-sentinel-port')
+        template.replaceAllNamed('config-command', 'config-command')
+        template.replaceAllNamed('slaveof-command', 'slaveof-command')
+        when:
+        def output = template.build()
+
+        then:
+        output == expected
+    }
+
+
     def "instance number is counted correctly"() {
         expect:
         new BoshTemplate(readTemplate(MONGODB_TEMPLATE)).instanceCount() == 3


### PR DESCRIPTION
The now deprecated replace method of BoshTemplate was calling two times
to string replaceAll method. With replaceAllNamed we are just calling
once.

With the added replaceAll we could pass the regular expression to be used.