### PR TITLE
bug: Return a copy of customized service details

### DIFF
--- a/broker/core/bosh-service/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/core/bosh-service/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -92,7 +92,7 @@ class BoshFacade {
 
         updateTemplateFromDatabaseConfiguration(template, parameters)
 
-        Collection<ServiceDetail> result = templateCustomizer.customizeBoshTemplate(template, serviceInstanceGuid) ?: []
+        Collection<ServiceDetail> result = new ArrayList<>(templateCustomizer.customizeBoshTemplate(template, serviceInstanceGuid) ?: [])
 
         result.add(ServiceDetail.from(BOSH_DEPLOYMENT_ID, generateDeploymentId(serviceInstanceGuid)))
         result.add(ServiceDetail.from(BOSH_TASK_ID_FOR_DEPLOY, this.boshClient.postDeployment(template.build()), true))


### PR DESCRIPTION
The bosh template customizer could return an Immutable collection that
makes this method fail.