### PR TITLE
chore: Only launch functional tests before release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,11 @@ workflows:
       - functional_test:
           requires:
             - integration_test
+          filters:
+            branches:
+              only: develop
+            tags:
+              only: /v.*/
       - tag_release:
           requires:
             - integration_test


### PR DESCRIPTION
Functional tests are taking around half an hour and we were launching
them when merging the  branch and when releasing the tag. Starting from
now, just launching them when releasing the tag: when merging the branch
they are not launched. That way, developers can update their develop
branch with the merged change and use a SNAPSHOT dependecy locally while
circle-ci is building the release.