### PR TITLE
chore: remove unnecessary credhub config

### DIFF
--- a/broker/core/src/main/resources/application.yml
+++ b/broker/core/src/main/resources/application.yml
@@ -5,24 +5,6 @@ spring.profiles:
 spring:
   profiles: default
 
-  security:
-    oauth2:
-      client:
-        registration:
-          credhub-client:
-            provider: uaa
-            client-id: credhub_client
-            client-secret: secret
-            authorization-grant-type: client_credentials
-          bosh-client:
-            provider: uaa
-            client-id: credhub_client
-            client-secret: secret
-            authorization-grant-type: client_credentials
-        provider:
-          uaa:
-            token-uri: http://localhost:8081/uaa/oauth/token
-
 management:
   metrics:
     export:


### PR DESCRIPTION
The config in application.yml should be as small as possible, to reduce
the risk of having test config in production systems. Therefore removing
credhub config which is not a default for production.