### PR TITLE
Feature/add multiple identical key handling for inventory

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
@@ -1,89 +1,71 @@
 package com.swisscom.cloud.sb.broker.services.inventory
 
+import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import org.springframework.data.util.Pair
 
 interface InventoryService {
     /**
-     * Get a single KeyValuePair by a Key for a given ServiceInstance.
-     *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param key key of the KeyValuePair.
-     * @return KeyValuePair
+     * @return First {@link Pair} with given key; If no {@link Pair} is found an {@link IllegalStateException} is thrown.
      */
     Pair<String, String> get(String serviceInstanceGuid, String key)
 
     /**
-     * Get a single KeyValuePair by a given Key for a given ServiceInstance - will return a default value if no KeyValuePair
-     * matching this configuration matches.
+     * Get all {@link Pair} for a given Key for a given {@link ServiceInstance} (this is especially useful if the key is not unique).
      *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param key Key of the KeyValuePair.
-     * @param defaultValue Default Value to be returned
-     * @return KeyValuePair
-     */
-    Pair<String, String> get(String serviceInstanceGuid, String key, String defaultValue)
-
-    /**
-     * Get all KeyValuePairs for a given Key for a given ServiceInstance (this is especially useful if the key is not unique).
-     *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param key Key of the KeyValuePair.
-     * @return List of KeyValuePair
+     * @return All {@link Pair} for a given key (including duplicates) for a given {@link ServiceInstance}.
      */
     List<Pair<String, String>> getAll(String serviceInstanceGuid, String key)
 
     /**
-     * Get all KeyValuePairs for a given ServiceInstance.
-     *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @return List of all KeyValuePair for this ServiceInstance.
+     * Get the first {@link Pair} by a given Key for a given {@link ServiceInstance} - will return a {@link Pair} with the
+     * default value if no {@link Pair} matching this configuration exists.
      */
+    Pair<String, String> get(String serviceInstanceGuid, String key, String defaultValue)
+
+    /**
+     * @deprecated Use {@link InventoryService#getAll()} instead.
+     */
+    @Deprecated
     List<Pair<String, String>> get(String serviceInstanceGuid)
 
     /**
-     * Sets a KeyValuePair for a given ServiceInstance replacing previous instances if necessary.
+     * @return All {@link Pair}s of the  {@link ServiceInstance}.
+     */
+    List<Pair<String, String>> getAll(String serviceInstanceGuid)
+
+    /**
+     * Create or Updates a {@link Pair} for a given {@link ServiceInstance}; Will only update the first {@link Pair} if
+     * multiple duplicated keys exist.
      *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @return List of all KeyValuePair for this ServiceInstance.
+     * @return All {@link Pair}s of the {@link ServiceInstance}.
      */
     List<Pair<String, String>> set(String serviceInstanceGuid, Pair<String, String> data)
 
     /**
-     * Replaces all KeyValuePair for a given ServiceInstance with a new List of KeyValuePair; all KeyValuePairs not in
-     * the data List will be deleted.
+     * Replaces all {@link Pair} for a given {@link ServiceInstance} with a new List of {@link Pair}; all {@link Pair} not in
+     * the data list will be deleted.
      *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param data List of all KeyValuePair to be set for this ServiceInstance.
-     * @return List of all KeyValuePair for this ServiceInstance.
+     * @return All {@link Pair}s of the {@link ServiceInstance}.
      */
     List<Pair<String, String>> replace(String serviceInstanceGuid, List<Pair<String, String>> data)
 
     /**
-     * Adds a List of KeyValuePairs for a given ServiceInstance; not touching previously existing KeyValuePairs.
+     * Adds a list of {@link Pair}s for a given {@link ServiceInstance}; not touching previously existing {@link Pair}s.
      *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param data List of KeyValuePair to be appended for this ServiceInstance.
-     * @return List of all KeyValuePair for this ServiceInstance.
+     * @return All {@link Pair}s of the {@link ServiceInstance}.
      */
     List<Pair<String, String>> append(String serviceInstanceGuid, List<Pair<String, String>> data)
 
     /**
-     * Deletes all KeyValuePairs for a given ServiceInstance for a given Key.
-     *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param key Key of the KeyValuePair.
-     * @return List of all KeyValuePair for this ServiceInstance.
+     * @return All {@link Pair}s of the {@link ServiceInstance}.
      */
     List<Pair<String, String>> delete(String serviceInstanceGuid, String key)
 
     /**
-     * Replaces or Creates all KeyValuePairs with a given Key for a given ServiceInstance; Not touching any KeyValuePairs
+     * Replaces or Creates all {@link Pair}s with a given Key for a given {@link ServiceInstance}; Not touching any {@link Pair}s
      * not matching the given Key. This is especially useful for working with not unique keys.
      *
-     * @param serviceInstanceGuid Id of th ServiceInstance.
-     * @param key Key of the KeyValuePair.
-     * @param values
-     * @return List of all KeyValuePair for this ServiceInstance.
+     * @return All {@link Pair}s of the {@link ServiceInstance}.
      */
-    List<Pair<String, String>> replaceByKey(String serviceInstanceGuid, String key, String[] values)
+    List<Pair<String, String>> createOrReplaceByKey(String serviceInstanceGuid, String key, String[] values)
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
@@ -5,9 +5,11 @@ import org.springframework.data.util.Pair
 interface InventoryService {
     Pair<String, String> get(String serviceInstanceGuid, String key)
     Pair<String, String> get(String serviceInstanceGuid, String key, String defaultValue)
+    List<Pair<String, String>> getAll(String serviceInstanceGuid, String key)
     List<Pair<String, String>> get(String serviceInstanceGuid)
     List<Pair<String, String>> set(String serviceInstanceGuid, Pair<String, String> data)
     List<Pair<String, String>> replace(String serviceInstanceGuid, List<Pair<String, String>> data)
     List<Pair<String, String>> append(String serviceInstanceGuid, List<Pair<String, String>> data)
     List<Pair<String, String>> delete(String serviceInstanceGuid, String key)
+    List<Pair<String, String>> replaceByKey(String serviceInstanceGuid, String key, String[] values)
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
@@ -3,13 +3,87 @@ package com.swisscom.cloud.sb.broker.services.inventory
 import org.springframework.data.util.Pair
 
 interface InventoryService {
+    /**
+     * Get a single KeyValuePair by a Key for a given ServiceInstance.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param key key of the KeyValuePair.
+     * @return KeyValuePair
+     */
     Pair<String, String> get(String serviceInstanceGuid, String key)
+
+    /**
+     * Get a single KeyValuePair by a given Key for a given ServiceInstance - will return a default value if no KeyValuePair
+     * matching this configuration matches.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param key Key of the KeyValuePair.
+     * @param defaultValue Default Value to be returned
+     * @return KeyValuePair
+     */
     Pair<String, String> get(String serviceInstanceGuid, String key, String defaultValue)
+
+    /**
+     * Get all KeyValuePairs for a given Key for a given ServiceInstance (this is especially useful if the key is not unique).
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param key Key of the KeyValuePair.
+     * @return List of KeyValuePair
+     */
     List<Pair<String, String>> getAll(String serviceInstanceGuid, String key)
+
+    /**
+     * Get all KeyValuePairs for a given ServiceInstance.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @return List of all KeyValuePair for this ServiceInstance.
+     */
     List<Pair<String, String>> get(String serviceInstanceGuid)
+
+    /**
+     * Sets a KeyValuePair for a given ServiceInstance replacing previous instances if necessary.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @return List of all KeyValuePair for this ServiceInstance.
+     */
     List<Pair<String, String>> set(String serviceInstanceGuid, Pair<String, String> data)
+
+    /**
+     * Replaces all KeyValuePair for a given ServiceInstance with a new List of KeyValuePair; all KeyValuePairs not in
+     * the data List will be deleted.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param data List of all KeyValuePair to be set for this ServiceInstance.
+     * @return List of all KeyValuePair for this ServiceInstance.
+     */
     List<Pair<String, String>> replace(String serviceInstanceGuid, List<Pair<String, String>> data)
+
+    /**
+     * Adds a List of KeyValuePairs for a given ServiceInstance; not touching previously existing KeyValuePairs.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param data List of KeyValuePair to be appended for this ServiceInstance.
+     * @return List of all KeyValuePair for this ServiceInstance.
+     */
     List<Pair<String, String>> append(String serviceInstanceGuid, List<Pair<String, String>> data)
+
+    /**
+     * Deletes all KeyValuePairs for a given ServiceInstance for a given Key.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param key Key of the KeyValuePair.
+     * @return List of all KeyValuePair for this ServiceInstance.
+     */
     List<Pair<String, String>> delete(String serviceInstanceGuid, String key)
+
+    /**
+     * Replaces or Creates all KeyValuePairs with a given Key for a given ServiceInstance; Not touching any KeyValuePairs
+     * not matching the given Key. This is especially useful for working with not unique keys.
+     *
+     * @param serviceInstanceGuid Id of th ServiceInstance.
+     * @param key Key of the KeyValuePair.
+     * @param values
+     * @return List of all KeyValuePair for this ServiceInstance.
+     */
     List<Pair<String, String>> replaceByKey(String serviceInstanceGuid, String key, String[] values)
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/InventoryService.groovy
@@ -5,6 +5,11 @@ import org.springframework.data.util.Pair
 
 interface InventoryService {
     /**
+     * Checks if at least one {@link Pair} exists with the given key for a given {@link ServiceInstance}.
+     */
+    boolean has(String serviceInstanceGuid, String key);
+
+    /**
      * @return First {@link Pair} with given key; If no {@link Pair} is found an {@link IllegalStateException} is thrown.
      */
     Pair<String, String> get(String serviceInstanceGuid, String key)

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
@@ -1,6 +1,5 @@
 package com.swisscom.cloud.sb.broker.services.inventory
 
-import com.google.common.base.Preconditions
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import com.swisscom.cloud.sb.broker.repository.ServiceDetailRepository
@@ -9,9 +8,9 @@ import groovy.transform.CompileStatic
 import org.springframework.data.util.Pair
 import org.springframework.stereotype.Service
 
-import static org.apache.commons.lang.StringUtils.isNotBlank
 import static com.google.common.base.Preconditions.checkArgument
 import static com.google.common.base.Preconditions.checkState
+import static org.apache.commons.lang.StringUtils.isNotBlank
 
 @CompileStatic
 @Service
@@ -23,6 +22,7 @@ class LocalInventoryServiceImpl implements InventoryService {
     public static String ERROR_DETAIL_NOT_FOUND = "no details for key:%s found"
     public static String ERROR_DETAIL_NOT_UNIQUE = "multiple details for key:%s found"
     public static String ERROR_DETAIL_MANDATORY = "details are mandatory"
+    public static String ERROR_DETAIL_BLANK = "detail key may not be blank"
 
     private final ServiceInstanceRepository serviceInstanceRepository
     private final ServiceDetailRepository serviceDetailRepository
@@ -87,6 +87,7 @@ class LocalInventoryServiceImpl implements InventoryService {
     List<Pair<String, String>> set(String serviceInstanceGuid, Pair<String, String> data) {
         checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
         checkArgument(data != null, ERROR_DETAIL_MANDATORY)
+        checkArgument(isNotBlank(data.first), ERROR_DETAIL_BLANK)
 
         def serviceInstance = getServiceInstance(serviceInstanceGuid)
 
@@ -120,6 +121,7 @@ class LocalInventoryServiceImpl implements InventoryService {
     List<Pair<String, String>> replace(String serviceInstanceGuid, List<Pair<String, String>> data) {
         checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
         checkArgument(data != null, ERROR_DETAIL_MANDATORY)
+        checkArgument(data.size() == 0 || data.any { kvp -> isNotBlank(kvp.first) }, ERROR_DETAIL_BLANK)
 
         def serviceInstance = getServiceInstance(serviceInstanceGuid)
 
@@ -145,6 +147,7 @@ class LocalInventoryServiceImpl implements InventoryService {
     List<Pair<String, String>> append(String serviceInstanceGuid, List<Pair<String, String>> data) {
         checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
         checkArgument(data != null, ERROR_DETAIL_MANDATORY)
+        checkArgument(data.any { kvp -> isNotBlank(kvp.first) }, ERROR_DETAIL_BLANK)
 
         def serviceInstance = getServiceInstance(serviceInstanceGuid)
 

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
@@ -42,6 +42,14 @@ class LocalInventoryServiceImpl implements InventoryService {
     }
 
     @Override
+    boolean has(String serviceInstanceGuid, String key) {
+        checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
+        checkArgument(isNotBlank(key), ERROR_KEY_NOT_DEFINED)
+
+        return getServiceInstance(serviceInstanceGuid).details.findAll { d -> d.key.equalsIgnoreCase(key) }.size() > 0
+    }
+
+    @Override
     Pair<String, String> get(String serviceInstanceGuid, String key) {
         checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
         checkArgument(isNotBlank(key), ERROR_KEY_NOT_DEFINED)

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
@@ -76,6 +76,11 @@ class LocalInventoryServiceImpl implements InventoryService {
 
     @Override
     List<Pair<String, String>> get(String serviceInstanceGuid) {
+        return getAll(serviceInstanceGuid)
+    }
+
+    @Override
+    List<Pair<String, String>> getAll(String serviceInstanceGuid) {
         checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
 
         return getServiceInstance(serviceInstanceGuid).details
@@ -180,7 +185,7 @@ class LocalInventoryServiceImpl implements InventoryService {
     }
 
     @Override
-    List<Pair<String, String>> replaceByKey(String serviceInstanceGuid, String key, String[] values) {
+    List<Pair<String, String>> createOrReplaceByKey(String serviceInstanceGuid, String key, String[] values) {
         checkArgument(isNotBlank(serviceInstanceGuid), ERROR_SERVICE_INSTANCE_ID_NOT_DEFINED)
         checkArgument(isNotBlank(key), ERROR_KEY_NOT_DEFINED)
         checkArgument(values != null, ERROR_DETAIL_MANDATORY)

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImpl.groovy
@@ -52,6 +52,11 @@ class LocalInventoryServiceImpl implements InventoryService {
     }
 
     @Override
+    List<Pair<String, String>> getAll(String serviceInstanceGuid, String key) {
+        return null
+    }
+
+    @Override
     List<Pair<String, String>> get(String serviceInstanceGuid) {
         return getServiceInstance(serviceInstanceGuid).details
                 .findAll { d -> d.key && d.value }
@@ -137,5 +142,10 @@ class LocalInventoryServiceImpl implements InventoryService {
         }
 
         return get(serviceInstanceGuid)
+    }
+
+    @Override
+    List<Pair<String, String>> replaceByKey(String serviceInstanceGuid, String key, String[] values) {
+        return null
     }
 }

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
@@ -1,6 +1,5 @@
 package com.swisscom.cloud.sb.broker.services.inventory
 
-import com.swisscom.cloud.sb.broker.error.ServiceBrokerException
 import com.swisscom.cloud.sb.broker.model.ServiceDetail
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import com.swisscom.cloud.sb.broker.repository.ServiceDetailRepository
@@ -44,8 +43,8 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid, "key_test")
 
         then:
-        def ex = thrown(ServiceBrokerException)
-        ex.description.contains(guid)
+        def ex = thrown(IllegalArgumentException)
+        ex.message == "service instance with id:${guid} not found"
     }
 
     void "should get single pair if key exists"() {
@@ -83,8 +82,8 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid, "key_002")
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == "No details for key:key_002 found"
+        def ex = thrown(IllegalStateException)
+        ex.message == "no details for key:key_002 found"
     }
 
     void "should return correct value even though default value is set"() {
@@ -102,6 +101,7 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid, "key_001", "default_value_001")
 
         then:
+        noExceptionThrown()
         result != null
         result.first == key
         result.second == value
@@ -122,6 +122,7 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid, "key_002", "default_value_001")
 
         then:
+        noExceptionThrown()
         result != null
         result.first == "key_002"
         result.second == "default_value_001"
@@ -146,6 +147,7 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid)
 
         then:
+        noExceptionThrown()
         result != null
         result.size() == 3
         result.get(0).first == "key_001"
@@ -174,6 +176,7 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.getAll(guid, "key_001")
 
         then:
+        noExceptionThrown()
         result != null
         result.size() == 3
         result.get(0).first == "key_001"
@@ -202,8 +205,8 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid, "key_001")
 
         then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == "Multiple details for key:key_001 found"
+        def ex = thrown(IllegalStateException)
+        ex.message == "multiple details for key:key_001 found"
     }
 
     @Unroll
@@ -229,13 +232,12 @@ class LocalInventoryServiceImplSpec extends Specification {
 
         where:
         guid                                   | key       | message
-        null                                   | "key_001" | "Service Instance Guid cannot be null or empty"
-        ""                                     | "key_001" | "Service Instance Guid cannot be null or empty"
-        " "                                    | "key_001" | "Service Instance Guid cannot be null or empty"
-        "10280232"                             | "key_001" | "Service Instance Guid cannot be numeric'"
-        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "Key cannot be null or empty"
-        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "Key cannot be null or empty"
-        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "Key cannot be null or empty"
+        null                                   | "key_001" | "service instance guid cannot be null or empty"
+        ""                                     | "key_001" | "service instance guid cannot be null or empty"
+        " "                                    | "key_001" | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
     }
 
     void "should get multiple none existing values"() {

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
@@ -209,37 +209,6 @@ class LocalInventoryServiceImplSpec extends Specification {
         ex.message == "multiple details for key:key_001 found"
     }
 
-    @Unroll
-    void "should throw exception when trying to get keys with invalid arguments, instance guid '#guid' and key '#key'"() {
-        given:
-        def serviceInstance = new ServiceInstance(
-                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
-                details: [
-                        ServiceDetail.from("key_001", "value_001"),
-                        ServiceDetail.from("key_001", "value_002"),
-                        ServiceDetail.from("key_001", "value_003"),
-                        ServiceDetail.from("key_003", "value_003")
-                ]
-        )
-        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
-
-        when:
-        testee.get(guid, key)
-
-        then:
-        def ex = thrown(IllegalArgumentException)
-        ex.message == message
-
-        where:
-        guid                                   | key       | message
-        null                                   | "key_001" | "service instance guid cannot be null or empty"
-        ""                                     | "key_001" | "service instance guid cannot be null or empty"
-        " "                                    | "key_001" | "service instance guid cannot be null or empty"
-        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
-        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
-        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
-    }
-
     void "should get multiple none existing values"() {
         given:
         def guid = UUID.randomUUID().toString()
@@ -502,5 +471,280 @@ class LocalInventoryServiceImplSpec extends Specification {
         noExceptionThrown()
         result != null
         result.size() == 0
+    }
+
+    @Unroll
+    void "should throw exception when trying to get keyValuePairs with invalid arguments, instance guid '#guid' and key '#key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.get(guid, key)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | key       | message
+        null                                   | "key_001" | "service instance guid cannot be null or empty"
+        ""                                     | "key_001" | "service instance guid cannot be null or empty"
+        " "                                    | "key_001" | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
+    }
+
+    @Unroll
+    void "should throw exception when trying to get keyValuePairs with default with invalid arguments, instance guid '#guid' and key '#key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.get(guid, key, null)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | key       | message
+        null                                   | "key_001" | "service instance guid cannot be null or empty"
+        ""                                     | "key_001" | "service instance guid cannot be null or empty"
+        " "                                    | "key_001" | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
+    }
+
+    @Unroll
+    void "should throw exception when trying to getAll keyValuePairs with invalid arguments, instance guid '#guid' and key '#key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.getAll(guid, key)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | key       | message
+        null                                   | "key_001" | "service instance guid cannot be null or empty"
+        ""                                     | "key_001" | "service instance guid cannot be null or empty"
+        " "                                    | "key_001" | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
+    }
+
+    @Unroll
+    void "should throw exception when trying to get All keyValuePairs with invalid arguments, instance guid '#guid'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.get(guid)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | message
+        null                                   | "service instance guid cannot be null or empty"
+        ""                                     | "service instance guid cannot be null or empty"
+        " "                                    | "service instance guid cannot be null or empty"
+    }
+
+    @Unroll
+    void "should throw exception when trying to set keyValuePair with invalid arguments, instance guid '#guid' and data '#data_key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.set(guid, Pair.of(data_key, "value_001"))
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | data_key                            | message
+        null                                   | "key_001"                           | "service instance guid cannot be null or empty"
+        ""                                     | "key_001"                           | "service instance guid cannot be null or empty"
+        " "                                    | "key_001"                           | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""                                  | "detail key may not be blank"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | " "                                 | "detail key may not be blank"
+    }
+
+    @Unroll
+    void "should throw exception when trying to replace keyValuePair with invalid arguments, instance guid '#guid' and data '#data_key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.replace(guid, [ Pair.of(data_key, "value_001") ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | data_key                            | message
+        null                                   | "key_001"                           | "service instance guid cannot be null or empty"
+        ""                                     | "key_001"                           | "service instance guid cannot be null or empty"
+        " "                                    | "key_001"                           | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""                                  | "detail key may not be blank"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | " "                                 | "detail key may not be blank"
+    }
+
+    @Unroll
+    void "should throw exception when trying to append keyValuePair with invalid arguments, instance guid '#guid' and data '#data_key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.replace(guid, [ Pair.of(data_key, "value_001") ])
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | data_key                            | message
+        null                                   | "key_001"                           | "service instance guid cannot be null or empty"
+        ""                                     | "key_001"                           | "service instance guid cannot be null or empty"
+        " "                                    | "key_001"                           | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""                                  | "detail key may not be blank"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | " "                                 | "detail key may not be blank"
+    }
+
+    @Unroll
+    void "should throw exception when trying to delete keyValuePairs with invalid arguments, instance guid '#guid' and key '#key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+
+        when:
+        testee.delete(guid, key)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | key       | message
+        null                                   | "key_001" | "service instance guid cannot be null or empty"
+        ""                                     | "key_001" | "service instance guid cannot be null or empty"
+        " "                                    | "key_001" | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
+    }
+
+    @Unroll
+    void "should throw exception when trying to replaceByKey keyValuePairs with invalid arguments, instance guid '#guid' and key '#key'"() {
+        given:
+        def serviceInstance = new ServiceInstance(
+                guid: "d6445c23-275f-48b0-ac80-d0a04b3eae46",
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid("d6445c23-275f-48b0-ac80-d0a04b3eae46") >> serviceInstance
+        String[] values = [ "value_1", "value_2" ]
+
+
+        when:
+        testee.replaceByKey(guid, key, values)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message == message
+
+        where:
+        guid                                   | key       | message
+        null                                   | "key_001" | "service instance guid cannot be null or empty"
+        ""                                     | "key_001" | "service instance guid cannot be null or empty"
+        " "                                    | "key_001" | "service instance guid cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | null      | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | ""        | "key cannot be null or empty"
+        "d6445c23-275f-48b0-ac80-d0a04b3eae46" | "  "      | "key cannot be null or empty"
     }
 }

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
@@ -392,7 +392,7 @@ class LocalInventoryServiceImplSpec extends Specification {
 
         when:
         String[] data = ["value_002", "value_004"]
-        testee.replaceByKey(guid, "key_001", data)
+        testee.createOrReplaceByKey(guid, "key_001", data)
         def result = testee.get(guid)
 
         then:
@@ -419,7 +419,7 @@ class LocalInventoryServiceImplSpec extends Specification {
 
         when:
         String[] data = ["value_002", "value_004"]
-        testee.replaceByKey(guid, "key_001", data)
+        testee.createOrReplaceByKey(guid, "key_001", data)
         def result = testee.get(guid)
 
         then:
@@ -732,7 +732,7 @@ class LocalInventoryServiceImplSpec extends Specification {
 
 
         when:
-        testee.replaceByKey(guid, key, values)
+        testee.createOrReplaceByKey(guid, key, values)
 
         then:
         def ex = thrown(IllegalArgumentException)

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
@@ -43,7 +43,7 @@ class LocalInventoryServiceImplSpec extends Specification {
         def result = testee.get(guid, "key_test")
 
         then:
-        def ex = thrown(IllegalArgumentException)
+        def ex = thrown(IllegalStateException)
         ex.message == "service instance with id:${guid} not found"
     }
 

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/services/inventory/LocalInventoryServiceImplSpec.groovy
@@ -162,6 +162,35 @@ class LocalInventoryServiceImplSpec extends Specification {
         result.get(2).second == "value_003"
     }
 
+    void "should get multiple values with identical keys"() {
+        given:
+        def guid = UUID.randomUUID().toString()
+        def serviceInstance = new ServiceInstance(
+                guid: guid,
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid(guid) >> serviceInstance
+
+        when:
+        def result = testee.getAll(guid, "key_001")
+
+        then:
+        noExceptionThrown()
+        result != null
+        result.size() == 3
+        result.get(0).first == "key_001"
+        result.get(0).second == "value_001"
+        result.get(1).first == "key_001"
+        result.get(1).second == "value_002"
+        result.get(2).first == "key_001"
+        result.get(2).second == "value_003"
+    }
+
     void "can get multiple none existing values"() {
         given:
         def guid = UUID.randomUUID().toString()
@@ -336,6 +365,63 @@ class LocalInventoryServiceImplSpec extends Specification {
         result.get(3).second == "value_004_added"
         result.get(4).first == "key_005"
         result.get(4).second == "value_005_added"
+    }
+
+    void "should replace multiple values with identical keys correctly"() {
+        given:
+        def guid = UUID.randomUUID().toString()
+        def serviceInstance = new ServiceInstance(
+                guid: guid,
+                details: [
+                        ServiceDetail.from("key_001", "value_001"),
+                        ServiceDetail.from("key_001", "value_002"),
+                        ServiceDetail.from("key_001", "value_003"),
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid(guid) >> serviceInstance
+
+        when:
+        testee.replaceByKey(guid, "key_001", ["value_002", "value_004"])
+        def result = testee.get(guid)
+
+        then:
+        noExceptionThrown()
+        result != null
+        result.size() == 3
+        result.get(0).first == "key_001"
+        result.get(0).second == "value_002"
+        result.get(1).first == "key_001"
+        result.get(1).second == "value_004"
+        result.get(2).first == "key_003"
+        result.get(2).second == "value_003"
+    }
+
+    void "should add multiple values with identical keys while using replace correctly"() {
+        given:
+        def guid = UUID.randomUUID().toString()
+        def serviceInstance = new ServiceInstance(
+                guid: guid,
+                details: [
+                        ServiceDetail.from("key_003", "value_003")
+                ]
+        )
+        serviceInstanceRepository.findByGuid(guid) >> serviceInstance
+
+        when:
+        testee.replaceByKey(guid, "key_001", ["value_002", "value_004"])
+        def result = testee.get(guid)
+
+        then:
+        noExceptionThrown()
+        result != null
+        result.size() == 3
+        result.get(0).first == "key_003"
+        result.get(0).second == "value_003"
+        result.get(1).first == "key_001"
+        result.get(1).second == "value_002"
+        result.get(2).first == "key_001"
+        result.get(2).second == "value_004"
     }
 
     void "can empty"() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,10 @@ publishingDescription=Swisscom's Open Service Broker API implementation
 
 boshMocked=true
 boshPersisted=false
+boshUrl=<BASEURL OF YOUR BOSH>
+uaaUrl=<BASEURL OF UAA USED FOR AUTHENTICATION>
+boshUsername=<YOUR BOSH USERNAME>
+boshPassword=<YOUR BOSH PASSWORD>
 
 shieldMocked=true
 shieldUrl=http://localhost:8081


### PR DESCRIPTION
The inventory service didn't handle multiple service details with the same key 'properly'. I rectified this with adding a new function getAll and replaceByKey.