### PR TITLE
fix: Set eager fetch type for plans

### DIFF
--- a/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/PlanRepository.groovy
+++ b/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/PlanRepository.groovy
@@ -16,8 +16,13 @@
 package com.swisscom.cloud.sb.broker.repository
 
 import com.swisscom.cloud.sb.broker.model.Plan
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 
 interface PlanRepository extends BaseRepository<Plan, Integer> {
     Plan findByGuid(String guid)
+
+    @Query("SELECT p FROM Plan p JOIN FETCH p.parameters WHERE p.guid = (:guid)")
+    Plan findByGuidAndFetchParametersEagerly(@Param("guid") String guid)
 }

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
@@ -42,7 +42,7 @@ class ServiceInstance extends BaseModel{
     List<ServiceDetail> details = []
     @Column(name="plan_id", updatable = false, insertable = false)
     Integer planId
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name="plan_id")
     Plan plan
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
In a multithreaded environment we won't have access to the initial
session context that loaded this entity from database. So I added a
method for eager fetching the plan with its parameters and I modififed
the ServiceInstance relationship with Plan to be eager fetched
(otherwise metric calculation will fail in a different thread).