### PR TITLE
feat: Add method for fetch eagerly children of instance

### DIFF
--- a/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/ServiceInstanceRepository.groovy
+++ b/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/ServiceInstanceRepository.groovy
@@ -17,10 +17,15 @@ package com.swisscom.cloud.sb.broker.repository
 
 import com.swisscom.cloud.sb.broker.model.Plan
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.transaction.annotation.Transactional
 
 interface ServiceInstanceRepository extends BaseRepository<ServiceInstance, Integer>, ServiceInstanceRepositoryCustom {
     ServiceInstance findByGuid(String guid)
+
+    @Query("SELECT s FROM ServiceInstance s LEFT JOIN FETCH s.childs WHERE s.guid = (:guid)")
+    ServiceInstance findByGuidAndFetchChildsEagerly(@Param("guid") String guid)
 
     List<ServiceInstance> findByPlanIdIn(List<Integer> planIds)
 


### PR DESCRIPTION
We need to know the number of children in certain steps and places that
are not sharing same hibernate session, so with this method we can fetch
them eagerly.