### PR TITLE
fix: Add spring property so ClientOptions is loaded

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceProviderConfiguration.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceProviderConfiguration.groovy
@@ -22,7 +22,6 @@ class CredHubServiceProviderConfiguration {
     @ConditionalOnProperty("com.swisscom.cloud.sb.broker.credhub.url")
     @ConditionalOnMissingBean
     CredHubServiceProvider getBrokerDefault(
-            ClientOptions clientOptions,
             ClientRegistrationRepository clientRegistrationRepository,
             OAuth2AuthorizedClientService authorizedClientService,
             ServiceBindingRepository serviceBindingRepository) {
@@ -30,7 +29,7 @@ class CredHubServiceProviderConfiguration {
                 OAuth2CredHubService.of(
                         brokerCredHubUri,
                         brokerOAuth2RegistrationId,
-                        clientOptions,
+                        new ClientOptions(),
                         clientRegistrationRepository,
                         authorizedClientService
                 ),


### PR DESCRIPTION
We need ClientOptions for 'getBrokerDefault' Spring bean, and that bean
is conditional on property 'spring.credhub.url'