### PR TITLE
fix: Add Cascade.ALL to ServiceDetails of ServiceInstance

### DIFF
--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/util/ServiceDetailHelperSpec.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/util/ServiceDetailHelperSpec.groovy
@@ -40,7 +40,6 @@ class ServiceDetailHelperSpec extends BaseSpecification {
                 guid: UUID.randomUUID().toString(),
                 details: [ detail ]
         )
-        serviceDetailRepository.save(detail)
         serviceInstanceRepository.saveAndFlush(serviceInstance)
 
         when:
@@ -55,7 +54,6 @@ class ServiceDetailHelperSpec extends BaseSpecification {
 
         cleanup:
         serviceInstanceRepository.delete(serviceInstance)
-        serviceDetailRepository.delete(detail)
     }
 
     def 'Can resolve serviceInstance by key and value'() {
@@ -68,7 +66,6 @@ class ServiceDetailHelperSpec extends BaseSpecification {
                 guid: uuid,
                 details: [ detail ]
         )
-        serviceDetailRepository.save(detail)
         serviceInstanceRepository.saveAndFlush(serviceInstance)
 
         when:
@@ -85,6 +82,5 @@ class ServiceDetailHelperSpec extends BaseSpecification {
 
         cleanup:
         serviceInstanceRepository.delete(serviceInstance)
-        serviceDetailRepository.delete(detail)
     }
 }

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
@@ -56,6 +56,17 @@ class ServiceInstance extends BaseModel{
     @JoinColumn(name = "application_user_id")
     ApplicationUser applicationUser
 
+    /**
+     * Get the value of the desired ServiceDetail identified by its key
+     * FIXME we should use a Map for ServiceDetail instead of a List
+     *
+     * @param key the identifier of the ServiceDetail
+     * @return the value associated to the key
+     */
+    public String getDetail(String key){
+        details.find{d -> d.key == key}.value
+    }
+
     @Override
     String toString() {
         return "ServiceInstance{" +

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
@@ -35,7 +35,7 @@ class ServiceInstance extends BaseModel{
     @OneToMany
     @JoinColumn(name="service_instance_id")
     List<ServiceBinding> bindings = []
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "service_instance_service_detail",
             joinColumns = @JoinColumn(name = "service_instance_details_id"),
             inverseJoinColumns = @JoinColumn(name = "service_detail_id"))


### PR DESCRIPTION
When we want to delete a ServiceInstance we want to delete its details
also. And when we want to create a ServiceInstance we want to store its
ServiceDetails. So the correct cascade should be ALL.