### PR TITLE
chore: Store test results for all stages of build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,10 @@ jobs:
     steps:
       - checkout
       - run: ./gradlew build -x integrationTest -x functionalTest --stacktrace -PboshUrl=https://localhost:25555 -PuaaUrl=https://localhost:8443 -PboshUsername=admin -PboshPassword=aPassword
-  
+      - store_test_results:
+          path: broker/build/test-results
+      - store_artifacts:
+          path: broker/build/test-results
   
   # For integration testing we need to start a machine or setup_remote_docker because we need to use docker-compose for
   # having services up to launch the tests against
@@ -51,6 +54,10 @@ jobs:
       - run: sudo keytool -importkeystore -srckeystore broker/src/functional-test/resources/credhub_client.jks -srcstorepass changeit -destkeystore $(readlink -f /usr/bin/java | sed "s:bin/java::")/lib/security/cacerts -deststorepass changeit
       - run: pushd docker && ./setup_docker.sh ; popd
       - run: ./gradlew clean build -x test -x integrationTest --stacktrace -PboshUrl=https://localhost:25555 -PuaaUrl=https://localhost:8443 -PboshUsername=admin -PboshPassword=aPassword
+      - store_test_results:
+          path: broker/build/test-results
+      - store_artifacts:
+          path: broker/build/test-results
 
   # For tagging in the repository tags in the form 'vn.minor+1.0' or in the form 'vn.nn.patch+1'
   tag_release:


### PR DESCRIPTION
Otherwise we are not able to check fast which test is failing in
circle-ci.