### PR TITLE
fix: Rationalize relationships for bindings and instances

### DIFF
--- a/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/ServiceBindingRepository.groovy
+++ b/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/ServiceBindingRepository.groovy
@@ -17,9 +17,13 @@ package com.swisscom.cloud.sb.broker.repository
 
 import com.swisscom.cloud.sb.broker.model.ServiceBinding
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface ServiceBindingRepository extends BaseRepository<ServiceBinding, Integer> {
     ServiceBinding findByGuid(String guid)
+
+    @Query("select sb from ServiceBinding sb LEFT JOIN FETCH sb.details where sb.guid = (:guid) ")
+    ServiceBinding findByGuidAndFetchDetailsEagerly(@Param("guid") String guid)
 
     @Query("select sb from ServiceBinding sb where sb.credhubCredentialId is null")
     List<ServiceBinding> findNotMigratedCredHubBindings()

--- a/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/ServiceInstanceRepository.groovy
+++ b/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/repository/ServiceInstanceRepository.groovy
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional
 interface ServiceInstanceRepository extends BaseRepository<ServiceInstance, Integer>, ServiceInstanceRepositoryCustom {
     ServiceInstance findByGuid(String guid)
 
-    @Query("SELECT s FROM ServiceInstance s LEFT JOIN FETCH s.childs LEFT JOIN FETCH s.details WHERE s.guid = (:guid)")
+    @Query("SELECT s FROM ServiceInstance s LEFT JOIN FETCH s.childs LEFT JOIN FETCH s.details LEFT JOIN FETCH s.bindings WHERE s.guid = (:guid)")
     ServiceInstance findByGuidAndFetchChildsAndDetailsEagerly(@Param("guid") String guid)
 
     List<ServiceInstance> findByPlanIdIn(List<Integer> planIds)

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/LastOperation.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/LastOperation.groovy
@@ -88,4 +88,47 @@ class LastOperation extends BaseModel{
             return action
         }
     }
+
+    boolean equals(o) {
+        if (this.is(o)) {
+            return true
+        }
+        if (!(o instanceof LastOperation)) {
+            return false
+        }
+
+        LastOperation that = (LastOperation) o
+
+        if (dateCreation != that.dateCreation) {
+            return false
+        }
+        if (description != that.description) {
+            return false
+        }
+        if (guid != that.guid) {
+            return false
+        }
+        if (internalState != that.internalState) {
+            return false
+        }
+        if (operation != that.operation) {
+            return false
+        }
+        if (status != that.status) {
+            return false
+        }
+
+        return true
+    }
+
+    int hashCode() {
+        int result
+        result = guid.hashCode()
+        result = 31 * result + (operation != null ? operation.hashCode() : 0)
+        result = 31 * result + (dateCreation != null ? dateCreation.hashCode() : 0)
+        result = 31 * result + (status != null ? status.hashCode() : 0)
+        result = 31 * result + (description != null ? description.hashCode() : 0)
+        result = 31 * result + (internalState != null ? internalState.hashCode() : 0)
+        return result
+    }
 }

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceBinding.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceBinding.groovy
@@ -29,24 +29,24 @@ class ServiceBinding extends BaseModel {
     @Column(columnDefinition = 'text')
     String credentials //Credential in JSON format
     String parameters
-    @OneToMany(fetch = FetchType.LAZY)
+    @OneToMany(fetch =  FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "service_binding_service_detail",
             joinColumns = @JoinColumn(name = "service_binding_details_id"),
             inverseJoinColumns = @JoinColumn(name = "service_detail_id"))
     Set<ServiceDetail> details = []
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.EAGER)
     ServiceContext serviceContext
 
     @Column(name = 'service_instance_id', updatable = false, insertable = false)
     Integer serviceInstanceId
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = 'service_instance_id')
     @JsonIgnore
     ServiceInstance serviceInstance
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "application_user_id")
     ApplicationUser applicationUser
 
@@ -63,4 +63,6 @@ class ServiceBinding extends BaseModel {
                 ", serviceContext=" + serviceContext +
                 "}"
     }
+
+
 }

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceBinding.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceBinding.groovy
@@ -52,6 +52,17 @@ class ServiceBinding extends BaseModel {
 
     String credhubCredentialId
 
+    /**
+     * Get the value of the desired ServiceDetail identified by its key
+     * FIXME WE should implement a equals in ServiceDetail using its key so we could use collections get
+     *
+     * @param key the identifier of the ServiceDetail
+     * @return the value associated to the key
+     */
+    public String getDetail(String key){
+        details.find{d -> d.key == key}.value
+    }
+
     @Override
     String toString() {
         return "ServiceBinding{" +

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
@@ -32,9 +32,9 @@ class ServiceInstance extends BaseModel{
     Date dateDeleted
     @Column
     String parameters
-    @OneToMany
+    @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name="service_instance_id")
-    List<ServiceBinding> bindings = []
+    Set<ServiceBinding> bindings = []
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinTable(name = "service_instance_service_detail",
             joinColumns = @JoinColumn(name = "service_instance_details_id"),


### PR DESCRIPTION
In the case of the relationship of instances with bindings, we will need
to fetch the bindings of an instance when we are in different threads,
so included the left join. I have also changed fro List to Set because
otherwise Hibernate can't fetch two collections eagerly (we should use
Set instead of List always, but I can't change List<Details> because
there are dependencies to the List interface in other classes :-()

In the case of bindings I eagerly get the to-one relationships, cascade
all the details (because they don't make sense without being associated
to a binding) and added method for eagerly fetching Details (which we
need for sure when accessing from different threads).