### PR TITLE
fix: remove not blank check for service instance

### DIFF
--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceInstance.groovy
@@ -16,11 +16,9 @@
 package com.swisscom.cloud.sb.broker.model
 
 import javax.persistence.*
-import javax.validation.constraints.NotBlank
 
 @Entity
 class ServiceInstance extends BaseModel{
-    @NotBlank
     @Column(unique = true)
     String guid
     Date dateCreated = new Date()


### PR DESCRIPTION
The @NotBlank is incorrectly behaving in combination with the hibernate
validators: Error creating bean with name 'serviceDefinitionInitializer': Invocation of init method failed; nested exception is javax.validation.UnexpectedTypeException: HV000030: No validator could be found for constraint 'javax.validation.constraints.NotBlank' validating type 'java.lang.String'. Check configuration for 'guid'