### PR TITLE
refactor: Set preferred metric beans

### DIFF
--- a/broker/core/metrics/src/main/groovy/com/swisscom/cloud/sb/broker/metrics/MetricsConfiguration.groovy
+++ b/broker/core/metrics/src/main/groovy/com/swisscom/cloud/sb/broker/metrics/MetricsConfiguration.groovy
@@ -1,11 +1,11 @@
 package com.swisscom.cloud.sb.broker.metrics
 
-
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 
 @Configuration
 class MetricsConfiguration {
@@ -29,6 +29,7 @@ class MetricsConfiguration {
     }
 
     @Bean
+    @Primary
     @ConditionalOnProperty(name = "management.metrics.export.influx.enabled", havingValue = "true")
     List<PlanMetricService> getInfluxMetricServices(
             MeterRegistry meterRegistry,
@@ -50,6 +51,7 @@ class MetricsConfiguration {
     }
 
     @Bean
+    @Primary
     @ConditionalOnProperty(name = "management.metrics.export.influx.enabled", havingValue = "true")
     BindingMetricService getBindingMetricsService(
                     MeterRegistry meterRegistry,
@@ -62,6 +64,7 @@ class MetricsConfiguration {
     }
 
     @Bean
+    @Primary
     @ConditionalOnProperty(name = "management.metrics.export.influx.enabled", havingValue = "true")
     LastOperationMetricService getLastOperationMetricsService(
             MeterRegistry meterRegistry,


### PR DESCRIPTION
As there are multiple Beans found matching the metrics services
within the configuration, the "real" implementations should be
preferred over the "NoOp" implementations.