### PR TITLE
bug: Disallow null values for ServiceContextDetail

### DIFF
--- a/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/context/ServiceContextPersistenceService.groovy
+++ b/broker/core/database/src/main/groovy/com/swisscom/cloud/sb/broker/context/ServiceContextPersistenceService.groovy
@@ -22,14 +22,12 @@ import com.swisscom.cloud.sb.broker.repository.ServiceContextRepository
 import com.swisscom.cloud.sb.broker.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.util.servicecontext.ServiceContextHelper
 import groovy.transform.CompileStatic
-import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.cloud.servicebroker.model.CloudFoundryContext
 import org.springframework.cloud.servicebroker.model.Context
 import org.springframework.cloud.servicebroker.model.KubernetesContext
 import org.springframework.stereotype.Service
 
-@Slf4j
 @Service
 @CompileStatic
 class ServiceContextPersistenceService {
@@ -149,6 +147,6 @@ class ServiceContextPersistenceService {
     }
 
     private ServiceContextDetail createServiceContextDetailRecord(String key, String value, ServiceContext serviceContext) {
-        return serviceContextDetailRepository.saveAndFlush(new ServiceContextDetail(key: key, value: value, serviceContext: serviceContext))
+        return serviceContextDetailRepository.saveAndFlush(ServiceContextDetail.of(key, value, serviceContext))
     }
 }

--- a/broker/core/database/src/main/resources/db/migration/V1_0_26__update_disallow_null_value_in_service_context.sql
+++ b/broker/core/database/src/main/resources/db/migration/V1_0_26__update_disallow_null_value_in_service_context.sql
@@ -1,0 +1,4 @@
+UPDATE service_context_detail SET `_value` = '' WHERE `_value` is NULL;
+
+ALTER TABLE service_context_detail
+    MODIFY `_value` VARCHAR(255) NOT NULL;

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/context/ServiceContextHelperSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/context/ServiceContextHelperSpec.groovy
@@ -29,8 +29,8 @@ class ServiceContextHelperSpec extends Specification {
         setup:
         def serviceContext = new ServiceContext()
         serviceContext.platform = "cloudfoundry"
-        serviceContext.details << new ServiceContextDetail(key: ServiceContextHelper.CF_ORGANIZATION_GUID, value: "org_id")
-        serviceContext.details << new ServiceContextDetail(key: ServiceContextHelper.CF_SPACE_GUID, value: "space_id")
+        serviceContext.details << ServiceContextDetail.of(ServiceContextHelper.CF_ORGANIZATION_GUID, "org_id")
+        serviceContext.details << ServiceContextDetail.of(ServiceContextHelper.CF_SPACE_GUID, "space_id")
 
         when:
         def context = ServiceContextHelper.convertFrom(serviceContext) as CloudFoundryContext
@@ -45,7 +45,7 @@ class ServiceContextHelperSpec extends Specification {
         setup:
         def serviceContext = new ServiceContext()
         serviceContext.platform = "kubernetes"
-        serviceContext.details << new ServiceContextDetail(key: ServiceContextHelper.KUBERNETES_NAMESPACE, value: "my_namespace")
+        serviceContext.details << ServiceContextDetail.of( ServiceContextHelper.KUBERNETES_NAMESPACE, "my_namespace")
 
         when:
         def context = ServiceContextHelper.convertFrom(serviceContext) as KubernetesContext
@@ -60,7 +60,7 @@ class ServiceContextHelperSpec extends Specification {
         setup:
         def serviceContext = new ServiceContext()
         serviceContext.platform = "unknown"
-        serviceContext.details << new ServiceContextDetail(key: ServiceContextHelper.KUBERNETES_NAMESPACE, value: "my_namespace")
+        serviceContext.details << ServiceContextDetail.of(ServiceContextHelper.KUBERNETES_NAMESPACE, "my_namespace")
 
         when:
         def context = ServiceContextHelper.convertFrom(serviceContext) as Context

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AsyncServiceFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AsyncServiceFunctionalSpec.groovy
@@ -271,8 +271,8 @@ class AsyncServiceFunctionalSpec extends BaseFunctionalSpec {
         assert serviceInstance != null
         assert serviceInstance.serviceContext != null
         assert serviceInstance.serviceContext.platform == CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM
-        assert serviceInstance.serviceContext.details.<ServiceContextDetail>find { it.key == ServiceContextHelper.CF_ORGANIZATION_GUID }.value == org_guid
-        assert serviceInstance.serviceContext.details.<ServiceContextDetail>find { it.key == ServiceContextHelper.CF_SPACE_GUID }.value == space_guid
+        assert serviceInstance.serviceContext.details.<ServiceContextDetail>find { it.getKey() == ServiceContextHelper.CF_ORGANIZATION_GUID }.getValue() == org_guid
+        assert serviceInstance.serviceContext.details.<ServiceContextDetail>find { it.getKey() == ServiceContextHelper.CF_SPACE_GUID }.getValue() == space_guid
     }
 
     void assertKubernetesContext(String serviceInstanceGuid) {
@@ -280,7 +280,7 @@ class AsyncServiceFunctionalSpec extends BaseFunctionalSpec {
         assert serviceInstance != null
         assert serviceInstance.serviceContext != null
         assert serviceInstance.serviceContext.platform == KubernetesContext.KUBERNETES_PLATFORM
-        assert serviceInstance.serviceContext.details.<ServiceContextDetail>find { it.key == ServiceContextHelper.KUBERNETES_NAMESPACE }.value == "namespace_guid"
+        assert serviceInstance.serviceContext.details.<ServiceContextDetail>find { it.getKey() == ServiceContextHelper.KUBERNETES_NAMESPACE }.getValue() == "namespace_guid"
     }
 
 }

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/ServiceContextFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/ServiceContextFunctionalSpec.groovy
@@ -102,9 +102,9 @@ class ServiceContextFunctionalSpec extends BaseFunctionalSpec {
         noExceptionThrown()
         def serviceInstance = serviceInstanceRepository.findByGuid(serviceInstanceGuid)
         serviceInstance.serviceContext.platform == "CUSTOM"
-        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_a" }.value == "Some Value"
-        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_c" }.value == "13.37"
-        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_d" }.value == "1337"
+        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_a" }.getValue() == "Some Value"
+        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_c" }.getValue() == "13.37"
+        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_d" }.getValue() == "1337"
 
         when:
         context = new CustomContext([
@@ -119,9 +119,9 @@ class ServiceContextFunctionalSpec extends BaseFunctionalSpec {
         def serviceInstance2 = serviceInstanceRepository.findByGuid(serviceInstanceGuid)
         assert serviceInstance2
         serviceInstance2.serviceContext.platform == "CUSTOM"
-        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_a" }.value == "Some Other Value"
-        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_b" }.value == "Some New Value"
-        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_c" }.value == "42.42"
+        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_a" }.getValue() == "Some Other Value"
+        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_b" }.getValue() == "Some New Value"
+        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_c" }.getValue() == "42.42"
         serviceInstance2.serviceContext.details.size() == 3
 
         cleanup:
@@ -144,9 +144,9 @@ class ServiceContextFunctionalSpec extends BaseFunctionalSpec {
 
         ServiceInstance serviceInstance = serviceInstanceRepository.findByGuid(serviceInstanceGuid)
         serviceInstance.serviceContext.platform == "CUSTOM"
-        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_a" }.value == "Some Value"
-        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_c" }.value == "13.37"
-        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_d" }.value == "1337"
+        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_a" }.getValue() == "Some Value"
+        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_c" }.getValue() == "13.37"
+        serviceInstance.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_d" }.getValue() == "1337"
         serviceInstance.serviceContext.details.size() == 4
 
         when:
@@ -160,9 +160,9 @@ class ServiceContextFunctionalSpec extends BaseFunctionalSpec {
         def serviceInstance2 = serviceInstanceRepository.findByGuid(serviceInstanceGuid)
         assert serviceInstance2
         serviceInstance2.serviceContext.platform == "CUSTOM"
-        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_a" }.value == "Some Value"
-        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_c" }.value == "13.37"
-        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.key == "field_d" }.value == "1337"
+        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_a" }.getValue() == "Some Value"
+        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_c" }.getValue() == "13.37"
+        serviceInstance2.serviceContext.details.<ServiceContextDetail>find { d -> d.getKey() == "field_d" }.getValue() == "1337"
         serviceInstance2.serviceContext.details.size() == 4
 
         cleanup:

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedisSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/kubernetes/facade/redis/KubernetesFacadeRedisSpec.groovy
@@ -191,8 +191,8 @@ kind: Namespace""")
         plan.setGuid("test")
         ServiceContext ctx = new ServiceContext()
         ctx.setPlatform("cloudfoundry")
-        ctx.setDetails([ServiceContextDetail.from("space_guid", "test"), ServiceContextDetail.from("organization_guid",
-                                                                                                   "test")].toSet())
+        ctx.setDetails([ServiceContextDetail.of("space_guid", "test"), ServiceContextDetail.of("organization_guid",
+                                                                                               "test")].toSet())
 
         when:
         List threads = new ArrayList()
@@ -245,8 +245,8 @@ kind: Namespace""")
     private void mockProvisionRequest() {
         def serviceContext = new ServiceContext()
         serviceContext.platform = CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM
-        serviceContext.details << new ServiceContextDetail(key: ServiceContextHelper.CF_ORGANIZATION_GUID, value: "ORG")
-        serviceContext.details << new ServiceContextDetail(key: ServiceContextHelper.CF_SPACE_GUID, value: "SPACE")
+        serviceContext.details << ServiceContextDetail.of(ServiceContextHelper.CF_ORGANIZATION_GUID, "ORG")
+        serviceContext.details << ServiceContextDetail.of(ServiceContextHelper.CF_SPACE_GUID, "SPACE")
 
         provisionRequest = Mock(ProvisionRequest)
         provisionRequest.getServiceInstanceGuid() >> "ID"

--- a/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProviderSpec.groovy
+++ b/broker/src/test/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBServiceProviderSpec.groovy
@@ -110,8 +110,8 @@ class MariaDBServiceProviderSpec extends Specification {
         def request = new ProvisionRequest(serviceInstanceGuid: serviceInstanceGuid, serviceContext: new ServiceContext(
                 platform: CloudFoundryContext.CLOUD_FOUNDRY_PLATFORM,
                 details: [
-                        ServiceContextDetail.from(ServiceContextHelper.CF_ORGANIZATION_GUID, 'my-org'),
-                        ServiceContextDetail.from(ServiceContextHelper.CF_SPACE_GUID, 'my-space')]
+                        ServiceContextDetail.of(ServiceContextHelper.CF_ORGANIZATION_GUID, 'my-org'),
+                        ServiceContextDetail.of(ServiceContextHelper.CF_SPACE_GUID, 'my-space')]
         ))
         mariaDBClient.databaseExists(db) >>> [false, true]
         when:

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceContextDetail.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/model/ServiceContextDetail.groovy
@@ -16,24 +16,74 @@
 package com.swisscom.cloud.sb.broker.model
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.google.common.base.Preconditions
 
 import javax.persistence.*
+import javax.validation.constraints.NotNull
 
 @Entity
 class ServiceContextDetail extends BaseModel {
 
     @Column(name = '_key')
-    String key
+    @NotNull
+    private String key
     @Column(name = '_value')
-    String value
+    @NotNull
+    private String value
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "service_context_id")
     @JsonIgnore
-    ServiceContext serviceContext
+    private ServiceContext serviceContext
 
-    static ServiceContextDetail from(String key, String value) {
-        return new ServiceContextDetail(key: key, value: value)
+    /**
+     * Public no-arg constructor is needed for JPA compliance for more infos check
+     * <a href="https://en.wikipedia.org/wiki/Java_Persistence_API">here</a>
+     */
+    ServiceContextDetail() {}
+
+    private ServiceContextDetail(String key, String value) {
+        this(key, value, null);
+    }
+
+    private ServiceContextDetail(String key, String value, ServiceContext serviceContext) {
+        Preconditions.checkNotNull(key, "Key is not allowed to be null for ServiceContextDetail")
+        Preconditions.checkNotNull(key, "Value is not allowed to be null for ServiceContextDetail")
+        this.key = key
+        this.value = value
+        this.serviceContext = serviceContext
+    }
+
+    static ServiceContextDetail of(String key, String value, ServiceContext serviceContext) {
+        return new ServiceContextDetail(key, value, serviceContext)
+    }
+
+    static ServiceContextDetail of(String key, String value) {
+        return new ServiceContextDetail(key, value)
+    }
+
+    String getKey() {
+        return key
+    }
+
+    void setKey(String key) {
+        this.key = key
+    }
+
+    String getValue() {
+        return value
+    }
+
+    void setValue(String value) {
+        this.value = value
+    }
+
+    ServiceContext getServiceContext() {
+        return serviceContext
+    }
+
+    void setServiceContext(ServiceContext serviceContext) {
+        this.serviceContext = serviceContext
     }
 
     @Override


### PR DESCRIPTION
`value` and `key` should not allow any null values
as this leads to problems later on (e.g. running
`hashCode()` throws a `NullPointerException`) and it
makes no sense to have a null value for those fields.