### PR TITLE
fix: switch to optional implementation

### DIFF
--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseDeprovisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseDeprovisionState.groovy
@@ -34,7 +34,7 @@ enum MongoDbEnterpriseDeprovisionState implements ServiceStateWithAction<MongoDb
     DISABLE_BACKUP_IF_ENABLED(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext context) {
-            Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext)
+            Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext.serviceInstance.details)
             Optional<String> replicaSetId = ServiceDetailsHelper.from(context.lastOperationJobContext.serviceInstance.details)
                     .findValue(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_REPLICA_SET)
 
@@ -56,9 +56,9 @@ enum MongoDbEnterpriseDeprovisionState implements ServiceStateWithAction<MongoDb
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext context) {
 
             ignore404 {
-                def optionalGroupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext)
-                if (optionalGroupId.isPresent()) {
-                    context.opsManagerFacade.undeploy(optionalGroupId.get())
+                Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext.serviceInstance.details)
+                if (groupId.isPresent()) {
+                    context.opsManagerFacade.undeploy(groupId.get())
                 }
             }
             return new StateChangeActionResult(go2NextState: true)
@@ -69,9 +69,9 @@ enum MongoDbEnterpriseDeprovisionState implements ServiceStateWithAction<MongoDb
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext context) {
             boolean automationConfigComplete
             boolean is404 = ignore404 {
-                def optionalGroupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext)
-                if (optionalGroupId.isPresent()) {
-                    automationConfigComplete = context.opsManagerFacade.isAutomationUpdateComplete(optionalGroupId.get())
+                Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext.serviceInstance.details)
+                if (groupId.isPresent()) {
+                    automationConfigComplete = context.opsManagerFacade.isAutomationUpdateComplete(groupId.get())
                 } else {
                     automationConfigComplete = true
                 }
@@ -83,9 +83,9 @@ enum MongoDbEnterpriseDeprovisionState implements ServiceStateWithAction<MongoDb
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext context) {
             ignore404 {
-                def optionalGroupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext)
-                if (optionalGroupId.isPresent()) {
-                    context.opsManagerFacade.deleteAllHosts(optionalGroupId.get())
+                Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext.serviceInstance.details)
+                if (groupId.isPresent()) {
+                    context.opsManagerFacade.deleteAllHosts(groupId.get())
                 }
             }
             return new StateChangeActionResult(go2NextState: true)
@@ -95,7 +95,10 @@ enum MongoDbEnterpriseDeprovisionState implements ServiceStateWithAction<MongoDb
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext context) {
             ignore404 {
-                context.opsManagerFacade.deleteGroup(ServiceDetailsHelper.from(context.lastOperationJobContext.serviceInstance.details).getValue(MongoDbEnterpriseServiceDetailKey.MONGODB_ENTERPRISE_GROUP_ID))
+                Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(context.lastOperationJobContext.serviceInstance.details)
+                if (groupId.isPresent()) {
+                    context.opsManagerFacade.deleteGroup(groupId.get())
+                }
             }
             return new StateChangeActionResult(go2NextState: true)
         }

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -61,7 +61,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
             int targetAgentCount = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_TARGET_AGENT_COUNT) as int
             return new StateChangeActionResult(go2NextState:
                     stateContext.opsManagerFacade.areAgentsReady(MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
-                                .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")}),
+                                .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support") }),
                             targetAgentCount))
         }
     }),
@@ -189,7 +189,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
     DELETE_DEFAULT_ALERTS(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
-            def groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+            Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
             return new StateChangeActionResult(go2NextState: !groupId.isPresent() || stateContext.opsManagerFacade.deleteDefaultAlerts(groupId.get()))
         }
     }),

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -16,6 +16,7 @@
 package com.swisscom.cloud.sb.broker.services.mongodb.enterprise.statemachine
 
 import com.google.common.annotations.VisibleForTesting
+import com.swisscom.cloud.sb.broker.error.ErrorCode
 import com.swisscom.cloud.sb.broker.model.LastOperation
 import com.swisscom.cloud.sb.broker.provisioning.lastoperation.LastOperationJobContext
 import com.swisscom.cloud.sb.broker.provisioning.statemachine.OnStateChange
@@ -58,7 +59,10 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
             int targetAgentCount = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_TARGET_AGENT_COUNT) as int
-            return new StateChangeActionResult(go2NextState: stateContext.opsManagerFacade.areAgentsReady(MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext), targetAgentCount))
+            return new StateChangeActionResult(go2NextState:
+                    stateContext.opsManagerFacade.areAgentsReady(MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+                                .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")}),
+                            targetAgentCount))
         }
     }),
     REQUEST_AUTOMATION_UPDATE(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
@@ -66,6 +70,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
             String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+                    .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")})
             int initialAutomationVersion = stateContext.opsManagerFacade.getAndCheckInitialAutomationGoalVersion(groupId)
             if (stateContext.lastOperationJobContext.updateRequest) {
                 return new StateChangeActionResult(
@@ -120,13 +125,12 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
                 log.info("Could not find a '${PLAN_PARAMETER_MONGODB_VERSION}' parameter in plan. Falling back to SB wide configuration.")
             return mongoDbVersion ?: context.mongoDbEnterpriseConfig.mongoDbVersion
         }
-    }
-
-    ),
+    }),
     CHECK_AUTOMATION_UPDATE_STATUS(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
             String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+                    .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")})
             if (stateContext.lastOperationJobContext.provisionRequest) {
                 int targetAutomationGoalVersion = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_TARGET_AUTOMATION_GOAL_VERSION) as int
                 return new StateChangeActionResult(go2NextState: stateContext.opsManagerFacade.isAutomationUpdateComplete(groupId, targetAutomationGoalVersion))
@@ -139,6 +143,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
             String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+                    .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")})
             String replicaSet = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_REPLICA_SET)
             updateBackupConfigurationIfEnabled(stateContext, groupId, replicaSet)
             return new StateChangeActionResult(go2NextState: true)
@@ -184,8 +189,8 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
     DELETE_DEFAULT_ALERTS(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
-            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
-            return new StateChangeActionResult(go2NextState: stateContext.opsManagerFacade.deleteDefaultAlerts(groupId))
+            def groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+            return new StateChangeActionResult(go2NextState: !groupId.isPresent() || stateContext.opsManagerFacade.deleteDefaultAlerts(groupId.get()))
         }
     }),
     PROVISION_SUCCESS(LastOperation.Status.SUCCESS, new NoOp())

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mongodb/enterprise/statemachine/MongoDbEnterpriseProvisionState.groovy
@@ -60,7 +60,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
             int targetAgentCount = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_TARGET_AGENT_COUNT) as int
             return new StateChangeActionResult(go2NextState:
-                    stateContext.opsManagerFacade.areAgentsReady(MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+                    stateContext.opsManagerFacade.areAgentsReady(MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext.serviceInstance.details)
                                 .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support") }),
                             targetAgentCount))
         }
@@ -69,7 +69,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
 
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
-            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext.serviceInstance.details)
                     .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")})
             int initialAutomationVersion = stateContext.opsManagerFacade.getAndCheckInitialAutomationGoalVersion(groupId)
             if (stateContext.lastOperationJobContext.updateRequest) {
@@ -129,7 +129,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
     CHECK_AUTOMATION_UPDATE_STATUS(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
-            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext.serviceInstance.details)
                     .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")})
             if (stateContext.lastOperationJobContext.provisionRequest) {
                 int targetAutomationGoalVersion = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_TARGET_AUTOMATION_GOAL_VERSION) as int
@@ -142,7 +142,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
     ENABLE_BACKUP_IF_CONFIGURED(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
-            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+            String groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext.serviceInstance.details)
                     .orElseThrow({ ErrorCode.SERVICEPROVIDER_INTERNAL_ERROR.throwNew("MongoDbGroupId is missing, contact support")})
             String replicaSet = ServiceDetailsHelper.from(stateContext.lastOperationJobContext.serviceInstance.details).getValue(MONGODB_ENTERPRISE_REPLICA_SET)
             updateBackupConfigurationIfEnabled(stateContext, groupId, replicaSet)
@@ -189,7 +189,7 @@ enum MongoDbEnterpriseProvisionState implements ServiceStateWithAction<MongoDbEn
     DELETE_DEFAULT_ALERTS(LastOperation.Status.IN_PROGRESS, new OnStateChange<MongoDbEnterperiseStateMachineContext>() {
         @Override
         StateChangeActionResult triggerAction(MongoDbEnterperiseStateMachineContext stateContext) {
-            Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext)
+            Optional<String> groupId = MongoDbEnterpriseServiceProvider.getMongoDbGroupId(stateContext.lastOperationJobContext.serviceInstance.details)
             return new StateChangeActionResult(go2NextState: !groupId.isPresent() || stateContext.opsManagerFacade.deleteDefaultAlerts(groupId.get()))
         }
     }),


### PR DESCRIPTION
Retrieve the service detail as an optional and handle missing values accordingly. in the deprovision case, we will accept it, as we want to roll back and should support deprovisions of incomplete provisions. for provision it should fail with a correct error.