### PR TITLE
fix: incorrect bean name for credHubServiceProvider.

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceProviderConfiguration.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/services/credhub/CredHubServiceProviderConfiguration.groovy
@@ -18,7 +18,8 @@ class CredHubServiceProviderConfiguration {
     @Value("com.swisscom.cloud.sb.broker.credhub.oauth2.registration-id")
     String brokerOAuth2RegistrationId
 
-    @Bean
+    // Name must be `credHubServiceProvider` so that the name is correctly resolved.
+    @Bean(name = "credHubServiceProvider")
     @ConditionalOnProperty("com.swisscom.cloud.sb.broker.credhub.url")
     @ConditionalOnMissingBean
     CredHubServiceProvider getBrokerDefault(


### PR DESCRIPTION
Resolving of the correct serviceProvider is done by a hard coded pattern, this was not
correct for credHubServiceProvider with this configuration.