### PR TITLE
feat: Information for service instance purge

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,3 +313,28 @@ This will mark the service instance to be cleaned up in the database, delete any
 bindings to this service instance and if the ServiceProvider provides SystemBackups, also deregisters the service
 instance from the backup system. This command should be used if the service instance cannot be removed anymore due to
 unavailability of the service instance in the backend.
+
+Example Response when purge is partly successful:
+```
+HTTP Status 200
+{
+  "purged_service_instance_guid": "a7d660aa-5919-430a-9b07-f5db7f456b55",
+  "deleted_bindings": 3,
+  "is_system_backup_provider": true,
+  "errors": [
+    "Failed to deregister from backup system"
+  ]
+}
+```
+
+Example Response when purge failed due to invalid service instance guid:
+```
+HTTP Status 400
+{
+  "purged_service_instance_guid": "a7d660aa-5919-430a-9b07-f5db7f456b55",
+  "errors": [
+    "Service Instance Guid 'a7d660aa-5919-430a-9b07-f5db7f456b55' does not exist"
+  ]
+}
+
+```

--- a/broker/core/configuration/src/main/groovy/com/swisscom/cloud/sb/broker/services/credential/CredentialStoreConfiguration.java
+++ b/broker/core/configuration/src/main/groovy/com/swisscom/cloud/sb/broker/services/credential/CredentialStoreConfiguration.java
@@ -53,8 +53,8 @@ public class CredentialStoreConfiguration {
 
     public static class CredHubConfigurationProperties {
         private URI url;
-        private List<String> cacerts = new ArrayList();
-        private Map<String, String> oauth2 = new HashMap();
+        private List<String> cacerts = new ArrayList<>();
+        private Map<String, String> oauth2 = new HashMap<>();
 
 
         public URI getUrl() {

--- a/broker/core/src/main/java/com/swisscom/cloud/sb/broker/cfextensions/ServiceInstancePurgeInformation.java
+++ b/broker/core/src/main/java/com/swisscom/cloud/sb/broker/cfextensions/ServiceInstancePurgeInformation.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 Swisscom (Switzerland) Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.swisscom.cloud.sb.broker.cfextensions;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+import javax.annotation.Nullable;
+import java.util.Set;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonDeserialize(builder = ServiceInstancePurgeInformation.Builder.class)
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PUBLIC, get = {"get*", "is*"})
+@Value.Immutable
+public abstract class ServiceInstancePurgeInformation {
+    @JsonProperty("purged_service_instance_guid")
+    public abstract String getPurgedServiceInstanceGuid();
+
+    @JsonProperty("deleted_bindings")
+    @Nullable
+    public abstract Integer getDeletedBindings();
+
+    @JsonProperty("is_system_backup_provider")
+    @Nullable
+    public abstract Boolean isSystemBackupProvider();
+
+    @JsonProperty("errors")
+    @Nullable
+    public abstract Set<String> getErrors();
+
+    public static class Builder extends ImmutableServiceInstancePurgeInformation.Builder {
+    }
+
+    public static ServiceInstancePurgeInformation.Builder serviceInstancePurgeInformation() {
+        return new ServiceInstancePurgeInformation.Builder();
+    }
+}

--- a/broker/src/functional-test/resources/application-test.yml
+++ b/broker/src/functional-test/resources/application-test.yml
@@ -1,0 +1,160 @@
+---
+spring:
+  profiles: test
+  jpa.properties.hibernate.id.new_generator_mappings: false
+  jpa.hibernate.enable_lazy_load_no_trans: true
+  jpa.properties.hibernate.enable_lazy_load_no_trans: true
+
+  datasource:
+    driverClassName: com.mysql.cj.jdbc.Driver
+    url: 'jdbc:mysql://localhost/CFBroker?autoReconnect=true'
+    username: root
+    password:
+
+  credhub:
+    url: https://localhost:9000
+    oauth2.registration-id: credhub-client
+  security:
+    oauth2:
+      client:
+        registration:
+          credhub-client:
+            provider: uaa
+            client-id: credhub_client
+            client-secret: secret
+            authorization-grant-type: client_credentials
+          bosh-client:
+            provider: uaa
+            client-id: credhub_client
+            client-secret: secret
+            authorization-grant-type: client_credentials
+        provider:
+          uaa:
+            token-uri: http://localhost:8081/uaa/oauth/token
+
+com.swisscom.cloud.sb.broker:
+  credhub:
+    url: https://localhost:9000
+    oauth2:
+      registration-id: credhub-client
+  services.bosh.client:
+    boshBaseUrl: https://192.168.50.6:25555
+    boshDirectorUsername: admin
+    boshDirectorPassword: 74v98dv1cuofsj4o8mct
+
+osb.credential.store: credhub
+
+com.swisscom.cloud.sb.broker.security.platformUsers:
+  - username: cc_admin
+    password: change_me
+    role: CF_ADMIN
+    platformId: 00000000-0000-0000-0000-000000000000
+  - username: cc_ext
+    password: change_me
+    role: CF_EXT_ADMIN
+    platformId: 00000000-0000-0000-0000-000000000000
+
+com.swisscom.cloud.sb.broker.service.mariadb:
+  nameOfDefault: "default"
+  clusters:
+    - name: "default"
+      driver: com.mysql.cj.jdbc.Driver
+      vendor: mysql
+      host: 127.0.0.1
+      port: 3306
+      adminUser: 'root'
+      adminPassword:
+      databasePrefix: 'cfdb_'
+      shieldAgentUrl: 'shield-agent:5444'
+      discoveryURL: "http://localhost:8080/v2/api-docs"
+      bindir: '/var/vcap/packages/shield-mysql/bin'
+      dashboardPath:
+
+com.swisscom.cloud.sb.broker.service.test-bosh-based-service:
+  retryIntervalInSeconds: 42
+  genericConfigs:
+    - templateName: test
+      type: cloud
+
+com.swisscom.cloud.sb.broker.bosh.credhub:
+  enable: false
+  url: https://localhost:9000
+  oauth2.registration-id: bosh-client
+
+com.swisscom.cloud.sb.broker.serviceDefinitions: [
+{
+  "guid": "7a495d86-73dc-4903-9b0b-140c9b011610",
+  "name": "credHubTest",
+  "description": "CredHub 2.0.0 Test",
+  "bindable": true,
+  "asyncRequired": false,
+  "internalName": "credHub",
+  "displayIndex": 1,
+  "metadata": {
+    "version": "2.0.0",
+    "displayName": "CredHub",
+    "bullets": [
+      "Secure Store"
+    ]
+  },
+  "plans": [
+  {
+    "guid": "0ef19631-1212-47cc-9c77-22d78ddaae3a",
+    "name": "test",
+    "description": "CredHub 2.0.0 Test",
+    "free": false,
+    "displayIndex": 0,
+    "metadata": {
+      "displayName": "test"
+    }
+  }
+  ]
+},
+{
+  "guid": "d40d962e-0890-43f1-b1a1-d454277346ff",
+  "name": "DummySystemBackup",
+  "description": "A Service Provider that provides System Backups",
+  "bindable": true,
+  "asyncRequired": false,
+  "internalName": "dummySystemBackup",
+  "displayIndex": 1,
+  "metadata": {
+    "version": "2.0.0",
+    "displayName": "DummySystemBackup",
+    "bullets": [
+      "Secure Store"
+    ]
+  },
+  "plans": [
+  {
+    "guid": "47273c6a-ff8b-40d6-9981-2b25663718a1",
+    "name": "test",
+    "description": "DummySystemBackup",
+    "free": false,
+    "displayIndex": 0,
+    "metadata": {
+      "displayName": "test"
+    }
+  }
+  ]
+}
+]
+
+com.swisscom.cloud.sb.broker.service.kubernetes.redis.v1:
+  kubernetesRedisHost: test
+
+com.swisscom.cloud.sb.broker.shield:
+  baseUrl: 'http://localhost:8082'
+  apiKey: 'api-key'
+  agent: 'shield-agent:5444'
+  jobPrefix: 'SB_CF_'
+  targetPrefix: 'SB_CF_'
+  storeName: 'local'
+  retentionName: 'default'
+  scheduleName: 'schedu'
+  maxRetryBackup: 5
+  username: admin
+  password: 'password'
+  maxNumberOfApiRetries: 3
+  waitBetweenApiRetries: 1s
+

--- a/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBConfig.groovy
+++ b/broker/src/main/groovy/com/swisscom/cloud/sb/broker/services/mariadb/MariaDBConfig.groovy
@@ -16,9 +16,9 @@
 package com.swisscom.cloud.sb.broker.services.mariadb
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import org.springframework.context.annotation.Configuration
+import org.springframework.stereotype.Component
 
-@Configuration
+@Component
 @ConfigurationProperties(prefix = 'com.swisscom.cloud.sb.broker.service.mariadb')
 class MariaDBConfig {
     String nameOfDefault


### PR DESCRIPTION
When purging a service instance, some helpful
information about the purge should be returned.
In practice `ServiceInstance` has been shown to
be unusable due to the huge amount of data.