### PR TITLE
refactor: Deregister user and system driven backup

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/BackupRestoreProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/BackupRestoreProvider.groovy
@@ -20,9 +20,13 @@ import com.swisscom.cloud.sb.broker.model.Backup
 import com.swisscom.cloud.sb.broker.model.Restore
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
 import groovy.transform.CompileStatic
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 @CompileStatic
 trait BackupRestoreProvider extends BackupOnShield {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackupRestoreProvider.class)
+
     def userBackupJobName(String jobPrefix, String serviceInstanceId) {
         backupJobName(jobPrefix, serviceInstanceId)
     }
@@ -69,8 +73,10 @@ trait BackupRestoreProvider extends BackupOnShield {
         return convertBackupStatus(status)
     }
 
-    void notifyServiceInstanceDeletion(ServiceInstance serviceInstance) {
-        shieldClient.deleteJobsAndBackups(serviceInstance.guid)
+    Map<String, Integer> notifyServiceInstanceDeletion(String serviceInstanceGuid) {
+        Map<String, Integer> result = shieldClient.deleteJobsAndBackups(serviceInstanceGuid)
+        LOGGER.debug("Deleted: {}", result)
+        return result
     }
 
     static Backup.Status convertBackupStatus(JobStatus status) {

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/BackupRestoreProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/BackupRestoreProvider.groovy
@@ -16,6 +16,7 @@
 package com.swisscom.cloud.sb.broker.backup
 
 import com.swisscom.cloud.sb.broker.async.job.JobStatus
+import com.swisscom.cloud.sb.broker.backup.shield.BackupDeregisterInformation
 import com.swisscom.cloud.sb.broker.model.Backup
 import com.swisscom.cloud.sb.broker.model.Restore
 import com.swisscom.cloud.sb.broker.model.ServiceInstance
@@ -73,9 +74,9 @@ trait BackupRestoreProvider extends BackupOnShield {
         return convertBackupStatus(status)
     }
 
-    Map<String, Integer> notifyServiceInstanceDeletion(String serviceInstanceGuid) {
-        Map<String, Integer> result = shieldClient.deleteJobsAndBackups(serviceInstanceGuid)
-        LOGGER.debug("Deleted: {}", result)
+    BackupDeregisterInformation notifyServiceInstanceDeletion(String serviceInstanceGuid) {
+        BackupDeregisterInformation result = shieldClient.deleteJobsAndBackups(serviceInstanceGuid)
+        LOGGER.debug(result.toString())
         return result
     }
 

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/BackupService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/BackupService.groovy
@@ -203,7 +203,7 @@ class BackupService {
 
     void notifyServiceInstanceDeletion(ServiceInstance serviceInstance) {
         if (backupRestoreProviderLookup.isBackupProvider(serviceInstance.plan)) {
-            backupRestoreProviderLookup.findBackupProvider(serviceInstance.plan).notifyServiceInstanceDeletion(serviceInstance)
+            backupRestoreProviderLookup.findBackupProvider(serviceInstance.plan).notifyServiceInstanceDeletion(serviceInstance.guid)
         }
     }
 

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/BackupDeregisterInformation.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/BackupDeregisterInformation.java
@@ -1,0 +1,29 @@
+package com.swisscom.cloud.sb.broker.backup.shield;
+
+import org.immutables.value.Value;
+
+import static java.lang.String.format;
+
+@Value.Immutable
+public abstract class BackupDeregisterInformation {
+    @Value.Default
+    public int getDeletedTargets() {
+        return 0;
+    }
+
+    @Value.Default
+    public int getDeletedJobs() {
+        return 0;
+    }
+
+    public static class Builder extends ImmutableBackupDeregisterInformation.Builder {}
+
+    public static BackupDeregisterInformation.Builder backupDeregisterInformation() {
+        return new BackupDeregisterInformation.Builder();
+    }
+
+    @Override
+    public String toString() {
+        return format("Backup Deregistering removed %d jobs and %d targets", getDeletedJobs(), getDeletedTargets());
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/BackupDeregisterInformation.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/BackupDeregisterInformation.java
@@ -2,21 +2,48 @@ package com.swisscom.cloud.sb.broker.backup.shield;
 
 import org.immutables.value.Value;
 
+import java.util.Collection;
+import java.util.HashSet;
+
 import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.join;
 
 @Value.Immutable
 public abstract class BackupDeregisterInformation {
+
+    /**
+     * @return names of deleted targets
+     */
     @Value.Default
-    public int getDeletedTargets() {
-        return 0;
+    public Collection<String> getDeletedTargets() {
+        return new HashSet<>();
     }
 
+    /**
+     * @return names of deleted jobs
+     */
     @Value.Default
-    public int getDeletedJobs() {
-        return 0;
+    public Collection<String> getDeletedJobs() {
+        return new HashSet<>();
     }
 
-    public static class Builder extends ImmutableBackupDeregisterInformation.Builder {}
+    @Value.Derived
+    public int getNumberOfDeletedTargets() {
+        return getDeletedTargets().size();
+    }
+
+    @Value.Derived
+    public int getNumberOfDeletedJobs() {
+        return getDeletedJobs().size();
+    }
+
+    @Value.Derived
+    public boolean deletedSomething() {
+        return getNumberOfDeletedJobs() > 0 || getNumberOfDeletedTargets() > 0;
+    }
+
+    public static class Builder extends ImmutableBackupDeregisterInformation.Builder {
+    }
 
     public static BackupDeregisterInformation.Builder backupDeregisterInformation() {
         return new BackupDeregisterInformation.Builder();
@@ -24,6 +51,10 @@ public abstract class BackupDeregisterInformation {
 
     @Override
     public String toString() {
-        return format("Backup Deregistering removed %d jobs and %d targets", getDeletedJobs(), getDeletedTargets());
+        return format("Backup Deregistering deleted %d jobs: [%s] and %d targets: [%s]",
+                      getNumberOfDeletedJobs(),
+                      join(getDeletedJobs(), ","),
+                      getNumberOfDeletedTargets(),
+                      join(getDeletedTargets(), ","));
     }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldRestClient.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldRestClient.groovy
@@ -29,6 +29,8 @@ interface ShieldRestClient {
 
     TargetDto getTargetByName(String name)
 
+    Collection<TargetDto> getTargetsByName(String name)
+
     UUID createTarget(String targetName, ShieldTarget target, String agent)
 
     UUID updateTarget(TargetDto existingTarget, ShieldTarget target, String agent)
@@ -38,6 +40,8 @@ interface ShieldRestClient {
     JobDto getJobByName(String name)
 
     JobDto getJobByUuid(UUID uuid)
+
+    Collection<JobDto> getJobsByName(String name)
 
     UUID createJob(String jobName,
                      UUID targetUuid,

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldRestClientV1.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldRestClientV1.groovy
@@ -15,12 +15,14 @@
 
 package com.swisscom.cloud.sb.broker.backup.shield
 
+import com.google.common.base.Preconditions
 import com.swisscom.cloud.sb.broker.backup.shield.dto.*
 import com.swisscom.cloud.sb.broker.util.RestTemplateBuilder
 import groovy.transform.PackageScope
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.vavr.control.Try
+import org.apache.commons.lang.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
@@ -37,6 +39,7 @@ import java.time.Duration
 import java.util.function.Function
 import java.util.function.Supplier
 
+import static com.google.common.base.Preconditions.checkArgument
 import static io.github.resilience4j.retry.IntervalFunction.ofExponentialBackoff
 import static io.github.resilience4j.retry.RetryConfig.custom
 import static org.springframework.http.HttpMethod.DELETE
@@ -182,6 +185,12 @@ class ShieldRestClientV1 implements ShieldRestClient {
         getTarget("?name=${name}")
     }
 
+    @Override
+    Collection<TargetDto> getTargetsByName(String name) {
+        checkArgument(StringUtils.isNotBlank(name), "Target name can not be empty")
+        getTargets("?name=${name}")
+    }
+
     TargetDto getTarget(String arguments) {
         def targets = getTargets(arguments)
         targets ? targets.first() : null
@@ -241,6 +250,12 @@ class ShieldRestClientV1 implements ShieldRestClient {
         execute({-> restTemplate.exchange(jobUrl(uuid), GET, configureRequestEntity(), JobDto[].class).getBody().first()
                 }, {ex -> ShieldApiException.of("Failed to get job", ex, uuid.toString())})
 
+    }
+
+    @Override
+    Collection<JobDto> getJobsByName(String name) {
+        checkArgument(StringUtils.isNotBlank(name), "Job name can not be empty")
+        getJobs("?name=${name}")
     }
 
     JobDto getJob(String arguments) {

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldRestClientV1.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldRestClientV1.groovy
@@ -15,14 +15,13 @@
 
 package com.swisscom.cloud.sb.broker.backup.shield
 
-import com.google.common.base.Preconditions
+
 import com.swisscom.cloud.sb.broker.backup.shield.dto.*
 import com.swisscom.cloud.sb.broker.util.RestTemplateBuilder
 import groovy.transform.PackageScope
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
 import io.vavr.control.Try
-import org.apache.commons.lang.StringUtils
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
@@ -42,10 +41,8 @@ import java.util.function.Supplier
 import static com.google.common.base.Preconditions.checkArgument
 import static io.github.resilience4j.retry.IntervalFunction.ofExponentialBackoff
 import static io.github.resilience4j.retry.RetryConfig.custom
-import static org.springframework.http.HttpMethod.DELETE
-import static org.springframework.http.HttpMethod.GET
-import static org.springframework.http.HttpMethod.POST
-import static org.springframework.http.HttpMethod.PUT
+import static org.apache.commons.lang.StringUtils.isNotBlank
+import static org.springframework.http.HttpMethod.*
 
 @PackageScope
 class ShieldRestClientV1 implements ShieldRestClient {
@@ -187,7 +184,7 @@ class ShieldRestClientV1 implements ShieldRestClient {
 
     @Override
     Collection<TargetDto> getTargetsByName(String name) {
-        checkArgument(StringUtils.isNotBlank(name), "Target name can not be empty")
+        checkArgument(isNotBlank(name), "Target name can not be empty")
         getTargets("?name=${name}")
     }
 
@@ -254,7 +251,7 @@ class ShieldRestClientV1 implements ShieldRestClient {
 
     @Override
     Collection<JobDto> getJobsByName(String name) {
-        checkArgument(StringUtils.isNotBlank(name), "Job name can not be empty")
+        checkArgument(isNotBlank(name), "Job name can not be empty")
         getJobs("?name=${name}")
     }
 

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ServiceInstanceCleanup.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ServiceInstanceCleanup.groovy
@@ -15,7 +15,7 @@
 
 package com.swisscom.cloud.sb.broker.provisioning
 
-import com.swisscom.cloud.sb.broker.backup.SystemBackupProvider
+import com.swisscom.cloud.sb.broker.backup.BackupRestoreProvider
 import com.swisscom.cloud.sb.broker.binding.ServiceBindingPersistenceService
 import com.swisscom.cloud.sb.broker.cfextensions.ServiceInstancePurgeInformation
 import com.swisscom.cloud.sb.broker.model.LastOperation
@@ -141,7 +141,7 @@ class ServiceInstanceCleanup {
         return result.
                 purgedServiceInstanceGuid(serviceInstanceGuid).
                 deletedBindings(deletedBindings).
-                systemBackupProvider(deregisteredFromBackup.getLeft()).
+                backupRestoreProvider(deregisteredFromBackup.getLeft()).
                 errors(errors).
                 build()
     }
@@ -176,9 +176,10 @@ class ServiceInstanceCleanup {
         }
         ServiceProvider serviceProvider = serviceProviderLookup.findServiceProvider(planWithService)
 
-        if (serviceProvider instanceof SystemBackupProvider) {
+        if (serviceProvider instanceof BackupRestoreProvider) {
             try {
-                serviceProvider.unregisterSystemBackupOnShield(serviceInstanceGuid)
+                Map<String, Integer> deletedObjects = serviceProvider.notifyServiceInstanceDeletion(serviceInstanceGuid)
+                LOGGER.info("Deleted {} jobs and {} targets", deletedObjects.get("jobs"), deletedObjects.get("targets"))
                 return Pair.of(true, "");
             } catch (Exception e) {
                 LOGGER.error("Failed to deregister service instance {} from backup system."

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ServiceInstanceCleanup.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/provisioning/ServiceInstanceCleanup.groovy
@@ -16,6 +16,7 @@
 package com.swisscom.cloud.sb.broker.provisioning
 
 import com.swisscom.cloud.sb.broker.backup.BackupRestoreProvider
+import com.swisscom.cloud.sb.broker.backup.shield.BackupDeregisterInformation
 import com.swisscom.cloud.sb.broker.binding.ServiceBindingPersistenceService
 import com.swisscom.cloud.sb.broker.cfextensions.ServiceInstancePurgeInformation
 import com.swisscom.cloud.sb.broker.model.LastOperation
@@ -178,8 +179,8 @@ class ServiceInstanceCleanup {
 
         if (serviceProvider instanceof BackupRestoreProvider) {
             try {
-                Map<String, Integer> deletedObjects = serviceProvider.notifyServiceInstanceDeletion(serviceInstanceGuid)
-                LOGGER.info("Deleted {} jobs and {} targets", deletedObjects.get("jobs"), deletedObjects.get("targets"))
+                BackupDeregisterInformation deletedObjects = serviceProvider.notifyServiceInstanceDeletion(serviceInstanceGuid)
+                LOGGER.info(deletedObjects.toString())
                 return Pair.of(true, "");
             } catch (Exception e) {
                 LOGGER.error("Failed to deregister service instance {} from backup system."

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummySynchronousBackupCapableServiceProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummySynchronousBackupCapableServiceProvider.groovy
@@ -91,9 +91,9 @@ class DummySynchronousBackupCapableServiceProvider implements ServiceProvider, B
     }
 
     @Override
-    void notifyServiceInstanceDeletion(ServiceInstance serviceInstance) {
-        log.info("notifyServiceInstanceDeletion for ${serviceInstance}")
-
+    Map<String, Integer> notifyServiceInstanceDeletion(String serviceInstanceGuid) {
+        log.info("notifyServiceInstanceDeletion for ${serviceInstanceGuid}")
+        return null
     }
 
     @Override

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummySynchronousBackupCapableServiceProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/test/DummySynchronousBackupCapableServiceProvider.groovy
@@ -16,6 +16,7 @@
 package com.swisscom.cloud.sb.broker.util.test
 
 import com.swisscom.cloud.sb.broker.backup.BackupRestoreProvider
+import com.swisscom.cloud.sb.broker.backup.shield.BackupDeregisterInformation
 import com.swisscom.cloud.sb.broker.backup.shield.ShieldTarget
 import com.swisscom.cloud.sb.broker.binding.BindRequest
 import com.swisscom.cloud.sb.broker.binding.BindResponse
@@ -91,7 +92,7 @@ class DummySynchronousBackupCapableServiceProvider implements ServiceProvider, B
     }
 
     @Override
-    Map<String, Integer> notifyServiceInstanceDeletion(String serviceInstanceGuid) {
+    BackupDeregisterInformation notifyServiceInstanceDeletion(String serviceInstanceGuid) {
         log.info("notifyServiceInstanceDeletion for ${serviceInstanceGuid}")
         return null
     }

--- a/broker/core/src/main/java/com/swisscom/cloud/sb/broker/cfextensions/ServiceInstancePurgeInformation.java
+++ b/broker/core/src/main/java/com/swisscom/cloud/sb/broker/cfextensions/ServiceInstancePurgeInformation.java
@@ -34,9 +34,9 @@ public abstract class ServiceInstancePurgeInformation {
     @Nullable
     public abstract Integer getDeletedBindings();
 
-    @JsonProperty("is_system_backup_provider")
+    @JsonProperty("is_backup_restore_provider")
     @Nullable
-    public abstract Boolean isSystemBackupProvider();
+    public abstract Boolean isBackupRestoreProvider();
 
     @JsonProperty("errors")
     @Nullable

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldClientTest.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldClientTest.groovy
@@ -208,10 +208,14 @@ class ShieldClientTest extends Specification {
         setupBackup(SHIELD_TEST + "DELETE-JOB", SHIELD_TEST + "DELETE-TARGET")
 
         when:
-        sut.deleteJobsAndBackups(SHIELD_TEST)
+        BackupDeregisterInformation result = sut.deleteJobsAndBackups(SHIELD_TEST)
 
         then:
-        noExceptionThrown()
+        result.deletedSomething()
+        result.getNumberOfDeletedJobs() == 1
+        result.getNumberOfDeletedTargets() == 1
+        result.getDeletedJobs().first() == SHIELD_TEST + "DELETE-JOB"
+        result.getDeletedTargets().first() == SHIELD_TEST + "DELETE-TARGET"
     }
 
     def "register and run system backup"() {

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AdminControllerSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AdminControllerSpec.groovy
@@ -121,7 +121,7 @@ class AdminControllerSpec extends Specification {
         result != null
         result.getPurgedServiceInstanceGuid() == serviceInstanceGuid
         result.getDeletedBindings() == 1
-        result.isSystemBackupProvider() == systemBackupProvider
+        result.isBackupRestoreProvider() == systemBackupProvider
         if (systemBackupProvider) {
             result.getErrors().size() == 1
             result.getErrors().contains("Failed to deregister from backup system")

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldBackupRestoreProviderSpec.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldBackupRestoreProviderSpec.groovy
@@ -23,6 +23,8 @@ import com.swisscom.cloud.sb.broker.provisioning.ProvisioningPersistenceService
 import org.springframework.http.HttpStatus
 import org.springframework.web.client.HttpClientErrorException
 
+import static com.swisscom.cloud.sb.broker.backup.shield.BackupDeregisterInformation.backupDeregisterInformation
+
 class ShieldBackupRestoreProviderSpec extends BaseTransactionalSpecification {
     class DummyShieldBackupRestoreProvider implements ShieldBackupRestoreProvider {
         DummyShieldBackupRestoreProvider() {
@@ -169,7 +171,7 @@ class ShieldBackupRestoreProviderSpec extends BaseTransactionalSpecification {
     def "notify service instance deletion"() {
         given:
         ServiceInstance instance = new ServiceInstance(guid: 'service-id')
-        1 * shieldClient.deleteJobsAndBackups('service-id')
+        1 * shieldClient.deleteJobsAndBackups('service-id') >> backupDeregisterInformation().build()
         when:
         shieldBackupRestoreProvider.notifyServiceInstanceDeletion(instance.guid)
         then:

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldBackupRestoreProviderSpec.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/backup/shield/ShieldBackupRestoreProviderSpec.groovy
@@ -171,7 +171,7 @@ class ShieldBackupRestoreProviderSpec extends BaseTransactionalSpecification {
         ServiceInstance instance = new ServiceInstance(guid: 'service-id')
         1 * shieldClient.deleteJobsAndBackups('service-id')
         when:
-        shieldBackupRestoreProvider.notifyServiceInstanceDeletion(instance)
+        shieldBackupRestoreProvider.notifyServiceInstanceDeletion(instance.guid)
         then:
         noExceptionThrown()
     }

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/provisioning/DummySystemBackupServiceProvider.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/provisioning/DummySystemBackupServiceProvider.groovy
@@ -15,6 +15,7 @@
 
 package com.swisscom.cloud.sb.broker.provisioning
 
+import com.swisscom.cloud.sb.broker.backup.BackupRestoreProvider
 import com.swisscom.cloud.sb.broker.backup.SystemBackupProvider
 import com.swisscom.cloud.sb.broker.backup.shield.ShieldTarget
 import com.swisscom.cloud.sb.broker.binding.BindRequest
@@ -31,7 +32,7 @@ import groovy.json.JsonGenerator
 import org.springframework.stereotype.Service
 
 @Service
-class DummySystemBackupServiceProvider implements SystemBackupProvider, ServiceProvider {
+class DummySystemBackupServiceProvider implements SystemBackupProvider, ServiceProvider, BackupRestoreProvider {
     private static final String SHIELD_TEST = "TEST-SYSTEM-BACKUP-PROVIDER"
     private static final String SHIELD_AGENT_URL = "127.0.0.1:5444"
 

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/provisioning/ServiceInstanceCleanupSpec.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/broker/provisioning/ServiceInstanceCleanupSpec.groovy
@@ -89,8 +89,8 @@ class ServiceInstanceCleanupSpec extends BaseSpecification {
         result != null
         result.getPurgedServiceInstanceGuid() == serviceInstanceGuid
         result.getDeletedBindings() == 1
-        result.isSystemBackupProvider() == systemBackupProvider
-        if (systemBackupProvider) {
+        result.isBackupRestoreProvider() == backupRestoreProvider
+        if (backupRestoreProvider) {
             result.getErrors().size() == 1
             result.getErrors().contains("Failed to deregister from backup system")
         } else {
@@ -115,7 +115,7 @@ class ServiceInstanceCleanupSpec extends BaseSpecification {
         serviceInstanceGuid << [UUID.randomUUID().toString(), UUID.randomUUID().toString()]
         bindingGuid << [UUID.randomUUID().toString(), UUID.randomUUID().toString()]
         planGuid << ["0ef19631-1212-47cc-9c77-22d78ddaae3a", "47273c6a-ff8b-40d6-9981-2b25663718a1"]
-        systemBackupProvider << [false, true]
+        backupRestoreProvider << [false, true]
     }
 
     @Unroll


### PR DESCRIPTION
When a customer uses the backup feature a job and target
are created in the shield system. With this change all
service instance associated backup resources are removed