### PR TITLE
bug: Set Correct Expected Status Code In Test

### DIFF
--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AsyncServiceFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/AsyncServiceFunctionalSpec.groovy
@@ -190,7 +190,7 @@ class AsyncServiceFunctionalSpec extends BaseFunctionalSpec {
 
         then:
         def ex = thrown(HttpClientErrorException)
-        ex.statusCode == HttpStatus.NOT_FOUND
+        ex.statusCode == HttpStatus.FORBIDDEN
     }
 
     def "provision and get service instance is retrievable"() {

--- a/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BindingParametersFunctionalSpec.groovy
+++ b/broker/src/functional-test/groovy/com/swisscom/cloud/sb/broker/functional/BindingParametersFunctionalSpec.groovy
@@ -109,7 +109,7 @@ class BindingParametersFunctionalSpec extends BaseFunctionalSpec {
 
         then:
         def ex = thrown(HttpClientErrorException)
-        ex.statusCode == HttpStatus.BAD_REQUEST
+        ex.statusCode == HttpStatus.FORBIDDEN
 
         cleanup:
         serviceBindingRepository.delete(serviceBindingRepository.findByGuid(serviceBindingGuid))


### PR DESCRIPTION
Not Retrievable response code was switched to FORBIDDEN.
The corresponding functional tests were not adapted to this
change.