### PR TITLE
bug: Log Sensitive Parameters As Confidential

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BaseController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BaseController.groovy
@@ -77,4 +77,9 @@ abstract class BaseController {
             it.getDefaultMessage()
         }).join(", ")
     }
+
+    public static String getSensitiveParameters(Map<String, Object> parameters) {
+        if (parameters == null) return ""
+        return "<CONFIDENTIAL> [Parameter Keys: " + parameters.keySet() + "]"
+    }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BaseController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/BaseController.groovy
@@ -77,9 +77,4 @@ abstract class BaseController {
             it.getDefaultMessage()
         }).join(", ")
     }
-
-    public static String getSensitiveParameters(Map<String, Object> parameters) {
-        if (parameters == null) return ""
-        return "<CONFIDENTIAL> [Parameter Keys: " + parameters.keySet() + "]"
-    }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningController.groovy
@@ -139,7 +139,8 @@ class ProvisioningController extends BaseController {
                               action             : Audit.AuditAction.Provision,
                               principal          : principal.name,
                               async              : acceptsIncomplete,
-                              parameters         : hasSensitiveData ? null : provisioningDto.parameters,
+                              parameters         : hasSensitiveData ? getSensitiveParameters(provisioningDto.parameters)
+                                                                    : provisioningDto.parameters,
                               failed             : failed
                       ])
         }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningController.groovy
@@ -88,21 +88,19 @@ class ProvisioningController extends BaseController {
                                                    @Valid @RequestBody ProvisioningDto provisioningDto,
                                                    Principal principal) {
         def failed = false
-        def hasSensitiveData = false
+        Map<String, Object> parametersForAudit = provisioningDto.getParameters()
 
         try {
             failIfServiceInstanceAlreadyExists(serviceInstanceGuid)
 
             def serviceProvider = serviceProviderLookup.findServiceProvider(getAndCheckPlan(provisioningDto.plan_id))
             if (serviceProvider instanceof SensitiveParameterProvider) {
-                LOGGER.
-                        info("Provision request for ServiceInstanceGuid: {}, ServiceId: {}",
+                LOGGER.info("Provision request for ServiceInstanceGuid: {}, ServiceId: {}",
                              serviceInstanceGuid,
                              provisioningDto?.service_id)
-                hasSensitiveData = true
+                parametersForAudit = serviceProvider.getSanitizedParameters(provisioningDto.getParameters())
             } else {
-                LOGGER.
-                        info("Provision request for ServiceInstanceGuid: {}, ServiceId: {}, Params: {}",
+                LOGGER.info("Provision request for ServiceInstanceGuid: {}, ServiceId: {}, Params: {}",
                              serviceInstanceGuid,
                              provisioningDto?.service_id,
                              provisioningDto.parameters)
@@ -139,8 +137,7 @@ class ProvisioningController extends BaseController {
                               action             : Audit.AuditAction.Provision,
                               principal          : principal.name,
                               async              : acceptsIncomplete,
-                              parameters         : hasSensitiveData ? getSensitiveParameters(provisioningDto.parameters)
-                                                                    : provisioningDto.parameters,
+                              parameters         : parametersForAudit,
                               failed             : failed
                       ])
         }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
@@ -63,11 +63,11 @@ class UpdatingController extends BaseController {
                                              @Valid @RequestBody UpdateDto updateDto,
                                              Principal principal) {
         def failed = false
-        def hasSensitiveData = false
+        Map<String, Object> parametersForAudit = updateDto.getParameters()
         try{
             log.info("Update request for ServiceInstanceGuid:${serviceInstanceGuid}, ServiceId: ${updateDto?.service_id}, Params: ${updateDto?.parameters}")
             ServiceInstance serviceInstance = getServiceInstanceOrFail(serviceInstanceGuid)
-            hasSensitiveData = updatingService.hasSensitiveParameters(serviceInstance.plan)
+            parametersForAudit = updatingService.getSanitizedSensitiveParameters(serviceInstance.getPlan(), updateDto?.getParameters())
             def updatingResponse = updatingService.update(
                     serviceInstance,
                     createUpdateRequest(serviceInstance, updateDto, acceptsIncomplete),
@@ -85,8 +85,7 @@ class UpdatingController extends BaseController {
                             principal: principal.name,
                             async: acceptsIncomplete,
                             failed: failed,
-                            parameters: hasSensitiveData ? getSensitiveParameters(updateDto.parameters)
-                                                         : updateDto.parameters
+                            parameters: parametersForAudit
                     ])
         }
     }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/controller/UpdatingController.groovy
@@ -85,7 +85,8 @@ class UpdatingController extends BaseController {
                             principal: principal.name,
                             async: acceptsIncomplete,
                             failed: failed,
-                            parameters: hasSensitiveData ? null : updateDto.parameters
+                            parameters: hasSensitiveData ? getSensitiveParameters(updateDto.parameters)
+                                                         : updateDto.parameters
                     ])
         }
     }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingService.groovy
@@ -31,10 +31,12 @@ class UpdatingService {
     protected ServiceProviderLookup serviceProviderLookup
     protected UpdatingPersistenceService updatingPersistenceService
 
-    boolean hasSensitiveParameters(Plan plan){
+    Map<String, Object> getSanitizedSensitiveParameters(Plan plan, Map<String, Object> parameters) {
         def serviceProvider = serviceProviderLookup.findServiceProvider(plan)
-
-        return serviceProvider != null && serviceProvider instanceof SensitiveParameterProvider
+        if (serviceProvider != null && serviceProvider instanceof SensitiveParameterProvider) {
+            return serviceProvider.getSanitizedParameters(parameters)
+        }
+        return parameters
     }
 
     @Autowired

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProvider.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProvider.groovy
@@ -1,5 +1,0 @@
-package com.swisscom.cloud.sb.broker.util
-
-interface SensitiveParameterProvider {
-
-}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProvider.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProvider.java
@@ -1,0 +1,25 @@
+package com.swisscom.cloud.sb.broker.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Some {@link com.swisscom.cloud.sb.broker.services.common.ServiceProvider}s
+ * require sensitive information, like passwords and certificates,
+ * in provision or update requests. All such providers must be marked with this
+ * interface.
+ */
+public interface SensitiveParameterProvider {
+    /**
+     * Provides the non-critical parts of parameters given
+     * in a provision or update request
+     * @param parameters given in the provision or update request
+     * @return the sanitized parameters
+     */
+    default Map<String, Object> getSanitizedParameters(Map<String, Object> parameters) {
+        Map<String, Object> result = new HashMap<>();
+        if (parameters == null) return result;
+        result.put("CONFIDENTIAL", parameters.keySet());
+        return result;
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProvider.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProvider.java
@@ -1,6 +1,7 @@
 package com.swisscom.cloud.sb.broker.util;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 /**
@@ -18,7 +19,10 @@ public interface SensitiveParameterProvider {
      */
     default Map<String, Object> getSanitizedParameters(Map<String, Object> parameters) {
         Map<String, Object> result = new HashMap<>();
-        if (parameters == null) return result;
+        if (parameters == null) {
+            result.put("CONFIDENTIAL", new HashSet<>());
+            return result;
+        };
         result.put("CONFIDENTIAL", parameters.keySet());
         return result;
     }

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningControllerSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningControllerSpec.groovy
@@ -27,7 +27,6 @@ import com.swisscom.cloud.sb.broker.repository.PlanRepository
 import com.swisscom.cloud.sb.broker.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.services.ServiceProviderLookup
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class ProvisioningControllerSpec extends Specification {
 
@@ -108,22 +107,6 @@ class ProvisioningControllerSpec extends Specification {
         where:
         serviceInstanceGuid          | _
         UUID.randomUUID().toString() | _
-
-    }
-
-    @Unroll
-    def 'getSensitiveParamters should return confidential string: #expectedString'() {
-        when:
-        String result = sut.getSensitiveParameters(parameters)
-
-        then:
-        result == expectedString
-
-        where:
-        parameters                      | expectedString
-        null                            | ""
-        ["test": "hello", "foo": "bar"] | "<CONFIDENTIAL> [Parameter Keys: [test, foo]]"
-        ["test": ["foo": "bar"]]        | "<CONFIDENTIAL> [Parameter Keys: [test]]"
     }
 }
 

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningControllerSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/controller/ProvisioningControllerSpec.groovy
@@ -27,6 +27,7 @@ import com.swisscom.cloud.sb.broker.repository.PlanRepository
 import com.swisscom.cloud.sb.broker.repository.ServiceInstanceRepository
 import com.swisscom.cloud.sb.broker.services.ServiceProviderLookup
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ProvisioningControllerSpec extends Specification {
 
@@ -108,6 +109,21 @@ class ProvisioningControllerSpec extends Specification {
         serviceInstanceGuid          | _
         UUID.randomUUID().toString() | _
 
+    }
+
+    @Unroll
+    def 'getSensitiveParamters should return confidential string: #expectedString'() {
+        when:
+        String result = sut.getSensitiveParameters(parameters)
+
+        then:
+        result == expectedString
+
+        where:
+        parameters                      | expectedString
+        null                            | ""
+        ["test": "hello", "foo": "bar"] | "<CONFIDENTIAL> [Parameter Keys: [test, foo]]"
+        ["test": ["foo": "bar"]]        | "<CONFIDENTIAL> [Parameter Keys: [test]]"
     }
 }
 

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProviderSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProviderSpec.groovy
@@ -20,7 +20,7 @@ class SensitiveParameterProviderSpec extends Specification {
 
         where:
         parameters                      | expectedMap
-        null                            | [:]
+        null                            | [CONFIDENTIAL: new HashSet()]
         ["test": "hello", "foo": "bar"] | [CONFIDENTIAL: new HashSet(["test", "foo"])]
         ["test": ["foo": "bar"]]        | [CONFIDENTIAL: new HashSet(["test"])]
     }

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProviderSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/util/SensitiveParameterProviderSpec.groovy
@@ -1,0 +1,27 @@
+package com.swisscom.cloud.sb.broker.util
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class SensitiveParameterProviderSpec extends Specification {
+    private SensitiveParameterProvider sut
+
+    def setup() {
+        sut = new SensitiveParameterProvider() {}
+    }
+
+    @Unroll
+    def 'getSanitizedParameters(#parameters) should return confidential string: #expectedMap'() {
+        when:
+        Map<String, Object> result = sut.getSanitizedParameters(parameters)
+
+        then:
+        result == new HashMap<String, Object>(expectedMap)
+
+        where:
+        parameters                      | expectedMap
+        null                            | [:]
+        ["test": "hello", "foo": "bar"] | [CONFIDENTIAL: new HashSet(["test", "foo"])]
+        ["test": ["foo": "bar"]]        | [CONFIDENTIAL: new HashSet(["test"])]
+    }
+}


### PR DESCRIPTION
Logging sensitive parameters as null can be misleading
as you cannot know whether any or which parameters are set.
With this change all top-level parameter keys are shown.