### PR TITLE
bug: sensitive provider does delete update request.

### DIFF
--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingService.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/updating/UpdatingService.groovy
@@ -53,10 +53,6 @@ class UpdatingService {
 
         def response = serviceProvider.update(updateRequest)
 
-        if(serviceProvider instanceof SensitiveParameterProvider){
-            updateRequest.parameters = null
-        }
-
         updatingPersistenceService.updatePlanAndServiceDetails(serviceInstance, updateRequest.parameters, response.details, updateRequest.plan, updateRequest.serviceContext)
         return response
     }


### PR DESCRIPTION
The update request is due to the lazy db removed from the update request table,
preventing any statemachine to access the values. This is not feasible.