### PR TITLE
bug: Update Should Be Persisted After Success

### DIFF
--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceConfig.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceConfig.groovy
@@ -1,0 +1,12 @@
+package com.swisscom.cloud.sb.broker
+
+import com.swisscom.cloud.sb.broker.services.AsyncServiceConfig
+import org.springframework.stereotype.Component
+
+@Component
+class DummyAsyncServiceConfig implements AsyncServiceConfig {
+    List<String> ipRanges = ["127.0.0.1"]
+    List<String> protocols = ["tcp"]
+    int retryIntervalInSeconds = 30
+    int maxRetryDurationInMinutes = 30
+}

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceConfig.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceConfig.groovy
@@ -1,9 +1,7 @@
 package com.swisscom.cloud.sb.broker
 
 import com.swisscom.cloud.sb.broker.services.AsyncServiceConfig
-import org.springframework.stereotype.Component
 
-@Component
 class DummyAsyncServiceConfig implements AsyncServiceConfig {
     List<String> ipRanges = ["127.0.0.1"]
     List<String> protocols = ["tcp"]

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceProvider.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceProvider.groovy
@@ -1,0 +1,55 @@
+package com.swisscom.cloud.sb.broker
+
+import com.google.common.base.Optional
+import com.swisscom.cloud.sb.broker.async.AsyncProvisioningService
+import com.swisscom.cloud.sb.broker.binding.BindRequest
+import com.swisscom.cloud.sb.broker.binding.BindResponse
+import com.swisscom.cloud.sb.broker.binding.UnbindRequest
+import com.swisscom.cloud.sb.broker.provisioning.ProvisioningPersistenceService
+import com.swisscom.cloud.sb.broker.provisioning.async.AsyncOperationResult
+import com.swisscom.cloud.sb.broker.provisioning.lastoperation.LastOperationJobContext
+import com.swisscom.cloud.sb.broker.services.AsyncServiceProvider
+import com.swisscom.cloud.sb.broker.updating.UpdatingPersistenceService
+import org.springframework.stereotype.Component
+
+@Component
+class DummyAsyncServiceProvider extends AsyncServiceProvider<DummyAsyncServiceConfig> {
+    private UpdatingPersistenceService updatingPersistenceService
+
+    DummyAsyncServiceProvider(AsyncProvisioningService asyncProvisioningService,
+                              ProvisioningPersistenceService provisioningPersistenceService,
+                              DummyAsyncServiceConfig serviceConfig,
+                              UpdatingPersistenceService updatingPersistenceService) {
+        super(asyncProvisioningService, provisioningPersistenceService, serviceConfig)
+        this.updatingPersistenceService = updatingPersistenceService
+    }
+
+    @Override
+    BindResponse bind(BindRequest request) {
+        return null
+    }
+
+    @Override
+    void unbind(UnbindRequest request) {
+
+    }
+
+    @Override
+    AsyncOperationResult requestUpdate(LastOperationJobContext context) {
+        updatingPersistenceService.updatePlan(context.getServiceInstance(),
+                                              context.getUpdateRequest().getParameters(),
+                                              context.getUpdateRequest().getPlan(),
+                                              context.getUpdateRequest().getServiceContext())
+        return null
+    }
+
+    @Override
+    Optional<AsyncOperationResult> requestDeprovision(LastOperationJobContext context) {
+        return null
+    }
+
+    @Override
+    AsyncOperationResult requestProvision(LastOperationJobContext context) {
+        return null
+    }
+}

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceProvider.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/DummyAsyncServiceProvider.groovy
@@ -10,9 +10,7 @@ import com.swisscom.cloud.sb.broker.provisioning.async.AsyncOperationResult
 import com.swisscom.cloud.sb.broker.provisioning.lastoperation.LastOperationJobContext
 import com.swisscom.cloud.sb.broker.services.AsyncServiceProvider
 import com.swisscom.cloud.sb.broker.updating.UpdatingPersistenceService
-import org.springframework.stereotype.Component
 
-@Component
 class DummyAsyncServiceProvider extends AsyncServiceProvider<DummyAsyncServiceConfig> {
     private UpdatingPersistenceService updatingPersistenceService
 


### PR DESCRIPTION
In the case of synchronous services updating a service
can be persisted as it is now in the UpdatingService.
For asynchronous services however it's problematic to
update the service instance on request, as it might fail
at a later stage and the service instance entry is then
in a wrong state.