### PR TITLE
bug: Fail Bosh Task On Error

### DIFF
--- a/broker/core/bosh-service/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
+++ b/broker/core/bosh-service/src/main/groovy/com/swisscom/cloud/sb/broker/services/bosh/BoshFacade.groovy
@@ -224,7 +224,7 @@ class BoshFacade {
         if (state == null) {
             throw new RuntimeException("Unknown bosh task state: ${state}")
         }
-        if ([BoshDirectorTask.State.CANCELLED, BoshDirectorTask.State.CANCELLING, BoshDirectorTask.State.ERRORED].contains(state)) {
+        if ([BoshDirectorTask.State.CANCELLED, BoshDirectorTask.State.CANCELLING, BoshDirectorTask.State.ERRORED, BoshDirectorTask.State.ERROR].contains(state)) {
             throw new RuntimeException("Task failed: ${taskId}")
         }
         return state.isSuccessful()


### PR DESCRIPTION
When the task response contains the state "error"
the task should be evaluated as failed.