### PR TITLE
wip: feature: add cleanup service logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,3 +337,31 @@ HTTP Status 400
 }
 
 ```
+
+### Cleanup Service Instances
+```
+[POST] /admin/cleanup
+```
+or
+```
+[POST] /admin/service_instances/{serviceInstanceGuid}/cleanup
+```
+
+Cleanup will try to execute the a custom configured cleanup action for all service instances (1)
+or for a single service instance (2). Per default the `all cleanup` will run every day in the morning
+at 02:15.
+
+As the cleanup is running on an async schedule, feedback to operators are sent via a different channel,
+the default channel is an `OpsGenie` integration. check https://docs.opsgenie.com/docs/alert-api for
+informations about how to retrieve a api key.
+
+The cleanup can be configured with the yaml configuration and by providing a `bean` of type `CleanupAction`.
+```
+com.swisscom.cloud.sb.broker.cleanup:
+    config.cleanupThresholdInDays: 30 (default is 30)
+    opsgenie:
+        apikey: "some-key"
+        alertPriority: "P3" (default is P3)
+        tags: [ "mongodb", "osb" ]
+        teams: [ "team1", "team2", "team3" ]
+```

--- a/broker/core/build.gradle
+++ b/broker/core/build.gradle
@@ -41,6 +41,8 @@ dependencies {
     compile libs.joda_time
     compile libs.commons_lang
 
+    // https://docs.opsgenie.com/docs/opsgenie-java-api
+    compile group: 'com.opsgenie.integration', name: 'sdk', version: '2.11.2'
 
     compile libs.httpclient
     compile libs.springfox_swagger2

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/AlertingClient.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/AlertingClient.java
@@ -1,0 +1,9 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+public interface AlertingClient {
+
+    /**
+     * Sends an alert to an Alerting backend.
+     */
+    void alert(Failure failure);
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupAction.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupAction.java
@@ -1,0 +1,7 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import reactor.core.publisher.Mono;
+
+public interface CleanupAction {
+    Mono<Boolean> executeCleanupServiceInstance(String serviceInstanceUuid);
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupConfiguration.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupConfiguration.java
@@ -1,0 +1,20 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@EnableScheduling
+public class CleanupConfiguration {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(CleanupConfiguration.class);
+
+    @Scheduled(cron = "0 15 2 * * *")
+    public void triggerCleanup() {
+        LOGGER.info("## Time: {}", LocalDateTime.now());
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupConfiguration.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupConfiguration.java
@@ -1,20 +1,55 @@
 package com.swisscom.cloud.sb.broker.cleanup;
 
+import com.swisscom.cloud.sb.broker.repository.ServiceInstanceRepository;
+import com.swisscom.cloud.sb.broker.services.inventory.InventoryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
-
-import java.time.LocalDateTime;
 
 @Configuration
-@EnableScheduling
+@ConfigurationProperties("com.swisscom.cloud.sb.broker.cleanup")
 public class CleanupConfiguration {
     protected static final Logger LOGGER = LoggerFactory.getLogger(CleanupConfiguration.class);
 
-    @Scheduled(cron = "0 15 2 * * *")
-    public void triggerCleanup() {
-        LOGGER.info("## Time: {}", LocalDateTime.now());
+    private OpsGenieAlertingClientConfiguration opsGenie;
+    private CleanupServiceConfiguration config;
+
+    @Bean
+    @ConditionalOnProperty(value = "com.swisscom.cloud.sb.broker.cleanup.opsgenie.apiKey")
+    public AlertingClient opsGenieAlertingClient() {
+        return new OpsGenieAlertingClient(getOpsGenie());
+    }
+
+    @Bean
+    @ConditionalOnBean(value = CleanupAction.class)
+    public CleanupService cleanupService(InventoryService inventoryService,
+                                         ServiceInstanceRepository instanceRepository,
+                                         AlertingClient alertingClient,
+                                         CleanupAction cleanupAction) {
+        return new CleanupService(getConfig(),
+                new CleanupInfoService(inventoryService),
+                instanceRepository,
+                alertingClient,
+                cleanupAction);
+    }
+
+    public OpsGenieAlertingClientConfiguration getOpsGenie() {
+        return opsGenie;
+    }
+
+    public void setOpsGenie(OpsGenieAlertingClientConfiguration opsGenie) {
+        this.opsGenie = opsGenie;
+    }
+
+    public CleanupServiceConfiguration getConfig() {
+        return config;
+    }
+
+    public void setConfig(CleanupServiceConfiguration cleanup) {
+        this.config = cleanup;
     }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupController.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupController.java
@@ -1,24 +1,36 @@
 package com.swisscom.cloud.sb.broker.cleanup;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.transaction.NotSupportedException;
 
 @RestController
 public class CleanupController {
     private final CleanupService cleanupService;
 
-    CleanupController(CleanupService cleanupService) {
+    CleanupController(@Autowired(required = false) CleanupService cleanupService) {
         this.cleanupService = cleanupService;
     }
 
-    @RequestMapping(value = "admin/cleanup/trigger", method = RequestMethod.POST)
-    void manualTriggerCleanup() {
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                cleanupService.triggerCleanup();
-            }
-        }).start();
+    @RequestMapping(value = "admin/cleanup", method = RequestMethod.POST)
+    void manualTriggerCleanup() throws NotSupportedException {
+        if (cleanupService == null) {
+            throw new NotSupportedException("cleanup is not supported for this OSB");
+        }
+
+        new Thread(() -> cleanupService.triggerCleanup()).start();
+    }
+
+    @RequestMapping(value = "admin/service_instances/{serviceInstanceUuid}/cleanup", method = RequestMethod.POST)
+    void manualTriggerCleanup(@PathVariable("serviceInstanceUuid") String serviceInstanceUuid) throws NotSupportedException {
+        if (cleanupService == null) {
+            throw new NotSupportedException("cleanup is not supported for this OSB");
+        }
+
+        new Thread(() -> cleanupService.triggerCleanup(serviceInstanceUuid)).start();
     }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupController.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupController.java
@@ -1,0 +1,24 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CleanupController {
+    private final CleanupService cleanupService;
+
+    CleanupController(CleanupService cleanupService) {
+        this.cleanupService = cleanupService;
+    }
+
+    @RequestMapping(value = "admin/cleanup/trigger", method = RequestMethod.POST)
+    void manualTriggerCleanup() {
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                cleanupService.triggerCleanup();
+            }
+        }).start();
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupInfoService.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupInfoService.java
@@ -1,0 +1,33 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import com.swisscom.cloud.sb.broker.services.inventory.InventoryService;
+import org.springframework.data.util.Pair;
+
+public class CleanupInfoService {
+    public static final String COMPLETED_STATE = "cleanup_completed";
+    public static final String PENDING_STATE = "cleanup_pending";
+    public static final String STATE_FIELD_NAME = "cleanup_state";
+
+    private final InventoryService inventoryService;
+
+    public CleanupInfoService(InventoryService inventoryService) {
+        this.inventoryService = inventoryService;
+    }
+
+    public String getState(String serviceInstanceUuid) {
+        return inventoryService.get(serviceInstanceUuid, STATE_FIELD_NAME, PENDING_STATE).getSecond();
+    }
+
+    public boolean isCompletedState(String serviceInstanceUuid) {
+        return getState(serviceInstanceUuid).equals(COMPLETED_STATE);
+    }
+
+    public String setState(String serviceInstanceUuid, String value) {
+        inventoryService.set(serviceInstanceUuid, Pair.of(STATE_FIELD_NAME, value));
+        return getState(serviceInstanceUuid);
+    }
+
+    public String setCompletedState(String serviceInstanceUuid) {
+        return setState(serviceInstanceUuid, COMPLETED_STATE);
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupService.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupService.java
@@ -48,6 +48,10 @@ public class CleanupService {
         LOGGER.debug("triggerCleanup() >> done");
     }
 
+    public void triggerCleanup(String serviceInstanceUuid) {
+        triggerServiceInstanceCleanup(serviceInstanceRepository.findByGuid(serviceInstanceUuid)).block();
+    }
+
     private Mono<Boolean> triggerServiceInstanceCleanup(ServiceInstance serviceInstance) {
         return Mono.just(serviceInstance.getGuid())
                 .publishOn(Schedulers.boundedElastic())

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupService.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupService.java
@@ -1,0 +1,97 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import com.google.common.base.Stopwatch;
+import com.swisscom.cloud.sb.broker.model.ServiceInstance;
+import com.swisscom.cloud.sb.broker.repository.ServiceInstanceRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+public class CleanupService {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(CleanupService.class);
+
+    private final CleanupServiceConfiguration cleanupServiceConfiguration;
+    private final CleanupInfoService cleanupInfoService;
+    private final ServiceInstanceRepository serviceInstanceRepository;
+    private final AlertingClient alertingClient;
+    private final CleanupAction cleanupAction;
+
+    CleanupService(CleanupServiceConfiguration cleanupServiceConfiguration,
+                   CleanupInfoService cleanupInfoService,
+                   ServiceInstanceRepository serviceInstanceRepository,
+                   AlertingClient alertingClient,
+                   CleanupAction cleanupAction) {
+        this.cleanupServiceConfiguration = cleanupServiceConfiguration;
+        this.cleanupInfoService = cleanupInfoService;
+        this.serviceInstanceRepository = serviceInstanceRepository;
+        this.alertingClient = alertingClient;
+        this.cleanupAction = cleanupAction;
+    }
+
+    public void triggerCleanup() {
+        LOGGER.debug("triggerCleanup()");
+
+        Mono.when(listCleanupServiceInstances().stream()
+                .map(this::triggerServiceInstanceCleanup)
+                .collect(Collectors.toList()))
+                .block();
+
+        LOGGER.debug("triggerCleanup() >> done");
+    }
+
+    private Mono<Boolean> triggerServiceInstanceCleanup(ServiceInstance serviceInstance) {
+        return Mono.just(serviceInstance.getGuid())
+                .publishOn(Schedulers.boundedElastic())
+                .flatMap(cleanupAction::executeCleanupServiceInstance)
+                .onErrorResume(ex -> {
+                    handleException(serviceInstance, ex);
+                    return Mono.just(false);
+                })
+                .doOnNext(r -> {
+                    if (r) {
+                        cleanupInfoService.setCompletedState(serviceInstance.getGuid());
+                    }
+                });
+    }
+
+    private void handleException(ServiceInstance serviceInstance, Throwable ex) {
+        alertingClient.alert(Failure.builder()
+                .message(format("Cleanup ServiceInstance failed for %s", serviceInstance.getGuid()))
+                .description(format("Error during cleanup: %s", ex.getMessage()))
+                .exception(ex)
+                .build());
+    }
+
+    private List<ServiceInstance> listCleanupServiceInstances() {
+        Stopwatch watch = Stopwatch.createStarted();
+        List<ServiceInstance> result = serviceInstanceRepository.findAll()
+                .stream()
+                .filter(ServiceInstance::isDeleted)
+                .filter(this::isAfterCleanupOffset)
+                .filter(this::isNotCleanupCompleted)
+                .collect(Collectors.toList());
+
+        LOGGER.info("Found {} service instances for cleanup, took: {}ms", result.size(), watch.elapsed(TimeUnit.MILLISECONDS));
+        return result;
+    }
+
+    private boolean isNotCleanupCompleted(ServiceInstance serviceInstance) {
+        return !cleanupInfoService.isCompletedState(serviceInstance.getGuid());
+    }
+
+    private boolean isAfterCleanupOffset(ServiceInstance serviceInstance) {
+        LOGGER.info("isAfterCleanupOffset({})", serviceInstance);
+        return serviceInstance.getDateDeleted().toInstant()
+                .plus(cleanupServiceConfiguration.getCleanupThresholdInDays(), ChronoUnit.DAYS)
+                .isBefore(Instant.now());
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupServiceConfiguration.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupServiceConfiguration.java
@@ -1,0 +1,14 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+public class CleanupServiceConfiguration {
+
+    private int cleanupThresholdInDays = 30;
+
+    public int getCleanupThresholdInDays() {
+        return cleanupThresholdInDays;
+    }
+
+    public void setCleanupThresholdInDays(int cleanupThresholdInDays) {
+        this.cleanupThresholdInDays = cleanupThresholdInDays;
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClient.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClient.java
@@ -1,0 +1,40 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import com.ifountain.opsgenie.client.OpsGenieClient;
+import com.ifountain.opsgenie.client.swagger.ApiException;
+import com.ifountain.opsgenie.client.swagger.api.AlertApi;
+import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.lang.String.format;
+
+public class OpsGenieAlertingClient implements AlertingClient {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(OpsGenieAlertingClient.class);
+    private final OpsGenieAlertingClientConfiguration configuration;
+    private final AlertApi apiClient;
+
+    public OpsGenieAlertingClient(OpsGenieAlertingClientConfiguration configuration) {
+        this.configuration = configuration;
+
+        apiClient = new OpsGenieClient().alertV2();
+        apiClient.getApiClient().setApiKey(configuration.getApiKey());
+    }
+
+    @Override
+    public void alert(Failure failure) {
+        LOGGER.error(failure.message(), failure.exception());
+
+        // https://docs.opsgenie.com/docs/opsgenie-java-api#create-alert
+        CreateAlertRequest createAlertRequest = new CreateAlertRequest();
+        createAlertRequest.setMessage(failure.message());
+        createAlertRequest.setDescription(format("%s <br /> %s", failure.description(), failure.exception().getMessage()));
+        createAlertRequest.setPriority(configuration.getAlertPriority());
+
+        try {
+            apiClient.createAlert(createAlertRequest);
+        } catch (ApiException alertException) {
+            LOGGER.error("Failed to send OpsGenie alert", alertException);
+        }
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClient.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClient.java
@@ -4,8 +4,11 @@ import com.ifountain.opsgenie.client.OpsGenieClient;
 import com.ifountain.opsgenie.client.swagger.ApiException;
 import com.ifountain.opsgenie.client.swagger.api.AlertApi;
 import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
+import com.ifountain.opsgenie.client.swagger.model.TeamRecipient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
@@ -18,6 +21,7 @@ public class OpsGenieAlertingClient implements AlertingClient {
         this.configuration = configuration;
 
         apiClient = new OpsGenieClient().alertV2();
+        apiClient.getApiClient().setBasePath(configuration.getBaseUrl());
         apiClient.getApiClient().setApiKey(configuration.getApiKey());
     }
 
@@ -25,11 +29,19 @@ public class OpsGenieAlertingClient implements AlertingClient {
     public void alert(Failure failure) {
         LOGGER.error(failure.message(), failure.exception());
 
+        // https://docs.opsgenie.com/docs/alert-api
         // https://docs.opsgenie.com/docs/opsgenie-java-api#create-alert
-        CreateAlertRequest createAlertRequest = new CreateAlertRequest();
-        createAlertRequest.setMessage(failure.message());
-        createAlertRequest.setDescription(format("%s <br /> %s", failure.description(), failure.exception().getMessage()));
-        createAlertRequest.setPriority(configuration.getAlertPriority());
+        CreateAlertRequest createAlertRequest = new CreateAlertRequest()
+                .message(configuration.getAlertMessage() + " " + failure.message())
+                .description(format("<br /> %s <br /> exception: %s",
+                        configuration.getAlertDescription(),
+                        failure.description(),
+                        failure.exception().getMessage()))
+                .teams(configuration.getTeams()
+                        .stream()
+                        .map(t -> new TeamRecipient().name(t)).collect(Collectors.toList()))
+                .tags(configuration.getTags())
+                .priority(configuration.getAlertPriority());
 
         try {
             apiClient.createAlert(createAlertRequest);

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClientConfiguration.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClientConfiguration.java
@@ -1,0 +1,24 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
+
+public class OpsGenieAlertingClientConfiguration {
+    private String apiKey;
+    private CreateAlertRequest.PriorityEnum alertPriority = CreateAlertRequest.PriorityEnum.P3;
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    public CreateAlertRequest.PriorityEnum getAlertPriority() {
+        return alertPriority;
+    }
+
+    public void setAlertPriority(CreateAlertRequest.PriorityEnum alertPriority) {
+        this.alertPriority = alertPriority;
+    }
+}

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClientConfiguration.java
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClientConfiguration.java
@@ -2,9 +2,17 @@ package com.swisscom.cloud.sb.broker.cleanup;
 
 import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class OpsGenieAlertingClientConfiguration {
+    private String baseUrl = "https://api.eu.opsgenie.com";
     private String apiKey;
-    private CreateAlertRequest.PriorityEnum alertPriority = CreateAlertRequest.PriorityEnum.P3;
+    private List<String> tags = new ArrayList<>();
+    private List<String> teams = new ArrayList<>();
+    private String alertDescription;
+    private String alertMessage;
+    private CreateAlertRequest.PriorityEnum alertPriority = CreateAlertRequest.PriorityEnum.P4;
 
     public String getApiKey() {
         return apiKey;
@@ -20,5 +28,45 @@ public class OpsGenieAlertingClientConfiguration {
 
     public void setAlertPriority(CreateAlertRequest.PriorityEnum alertPriority) {
         this.alertPriority = alertPriority;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public List<String> getTeams() {
+        return teams;
+    }
+
+    public void setTeams(List<String> teams) {
+        this.teams = teams;
+    }
+
+    public String getAlertDescription() {
+        return alertDescription;
+    }
+
+    public void setAlertDescription(String alertDescription) {
+        this.alertDescription = alertDescription;
+    }
+
+    public String getAlertMessage() {
+        return alertMessage;
+    }
+
+    public void setAlertMessage(String alertMessage) {
+        this.alertMessage = alertMessage;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
     }
 }

--- a/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/ScheduleConfiguration.groovy
+++ b/broker/core/src/main/groovy/com/swisscom/cloud/sb/broker/cleanup/ScheduleConfiguration.groovy
@@ -1,0 +1,21 @@
+package com.swisscom.cloud.sb.broker.cleanup
+
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+@EnableScheduling
+@ConditionalOnBean(value = CleanupService)
+class ScheduleConfiguration {
+    @Autowired()
+    CleanupService cleanupService;
+
+    @Scheduled(cron = "0 15 2 * * *")
+    void triggerCleanup() {
+        cleanupService.triggerCleanup();
+    }
+}

--- a/broker/core/src/main/java/com/swisscom/cloud/sb/broker/cleanup/Failure.java
+++ b/broker/core/src/main/java/com/swisscom/cloud/sb/broker/cleanup/Failure.java
@@ -1,0 +1,19 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface Failure {
+    static Builder builder() {
+        return new Builder();
+    }
+
+    String message();
+
+    String description();
+
+    Throwable exception();
+
+    class Builder extends ImmutableFailure.Builder {
+    }
+}

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupServiceSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cleanup/CleanupServiceSpec.groovy
@@ -1,0 +1,150 @@
+package com.swisscom.cloud.sb.broker.cleanup
+
+import com.swisscom.cloud.sb.broker.model.ServiceInstance
+import com.swisscom.cloud.sb.broker.repository.ServiceInstanceRepository
+import reactor.core.publisher.Mono
+import spock.lang.Ignore
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Instant
+
+class CleanupServiceSpec extends Specification {
+
+    CleanupServiceConfiguration cleanupServiceConfiguration = new CleanupServiceConfiguration()
+    CleanupInfoService cleanupInfoService = Mock(CleanupInfoService)
+    ServiceInstanceRepository serviceInstanceRepository = Mock(ServiceInstanceRepository)
+    AlertingClient alertingClient = Mock(AlertingClient)
+    CleanupAction cleanupAction = Mock(CleanupAction)
+
+    @Unroll
+    void 'triggerCleanup(): should trigger action (#executedCalled) with service instance (#deleted,#dateDeleted,#isCompletedState)'() {
+        given:
+        CleanupService sut = new CleanupService(cleanupServiceConfiguration,
+                cleanupInfoService,
+                serviceInstanceRepository,
+                alertingClient,
+                cleanupAction)
+
+        and:
+        String serviceInstanceUuid = UUID.randomUUID().toString()
+        1 * serviceInstanceRepository.findAll() >> [
+                new ServiceInstance(
+                        guid: serviceInstanceUuid,
+                        deleted: deleted,
+                        dateDeleted: Date.from(Instant.parse(dateDeleted))
+                )]
+
+        and:
+        (isCompletedStateCalled ? 1 : 0) * cleanupInfoService.isCompletedState(serviceInstanceUuid) >> isCompletedState
+
+        and:
+        (executedCalled ? 1 : 0) * cleanupAction.executeCleanupServiceInstance(serviceInstanceUuid) >> Mono.just(true)
+
+        when:
+        sut.triggerCleanup();
+
+        then:
+        noExceptionThrown();
+
+        and:
+        (executedCalled ? 1 : 0) * cleanupInfoService.setCompletedState(serviceInstanceUuid) >> true
+
+
+        where:
+        deleted | dateDeleted               | isCompletedState | isCompletedStateCalled | executedCalled
+        true    | "2019-01-01T00:00:00.00Z" | false            | true                   | true
+        true    | "2019-01-01T00:00:00.00Z" | true             | true                   | false
+        true    | Instant.now().toString()  | true             | false                  | false
+        false   | "2019-01-01T00:00:00.00Z" | false            | false                  | false
+    }
+
+    @Ignore
+    void 'triggerCleanup(): will do long runs in parallel and with fun'() {
+        given:
+        CleanupService sut = new CleanupService(cleanupServiceConfiguration,
+                cleanupInfoService,
+                serviceInstanceRepository,
+                alertingClient,
+                new LongRunningAction())
+
+        and:
+        String serviceInstanceUuid = UUID.randomUUID().toString()
+        1 * serviceInstanceRepository.findAll() >> [
+                new ServiceInstance(
+                        guid: UUID.randomUUID().toString(),
+                        deleted: true,
+                        dateDeleted: Date.from(Instant.parse("2019-01-01T00:00:00.00Z"))
+                ),
+                new ServiceInstance(
+                        guid: UUID.randomUUID().toString(),
+                        deleted: true,
+                        dateDeleted: Date.from(Instant.parse("2019-01-01T00:00:00.00Z"))
+                ),
+                new ServiceInstance(
+                        guid: UUID.randomUUID().toString(),
+                        deleted: true,
+                        dateDeleted: Date.from(Instant.parse("2019-01-01T00:00:00.00Z"))
+                ),
+                new ServiceInstance(
+                        guid: UUID.randomUUID().toString(),
+                        deleted: true,
+                        dateDeleted: Date.from(Instant.parse("2019-01-01T00:00:00.00Z"))
+                ),
+                new ServiceInstance(
+                        guid: UUID.randomUUID().toString(),
+                        deleted: true,
+                        dateDeleted: Date.from(Instant.parse("2019-01-01T00:00:00.00Z"))
+                )]
+
+        and:
+        cleanupInfoService.isCompletedState(serviceInstanceUuid) >> false
+
+        when:
+        sut.triggerCleanup();
+
+        then:
+        noExceptionThrown();
+    }
+
+    void 'triggerCleanup(): should alert if a cleanup failed'() {
+        given:
+        CleanupService sut = new CleanupService(cleanupServiceConfiguration,
+                cleanupInfoService,
+                serviceInstanceRepository,
+                alertingClient,
+                cleanupAction)
+
+        and:
+        String serviceInstanceUuid = UUID.randomUUID().toString()
+        1 * serviceInstanceRepository.findAll() >> [
+                new ServiceInstance(
+                        guid: serviceInstanceUuid,
+                        deleted: true,
+                        dateDeleted: Date.from(Instant.parse("2019-01-01T00:00:00.00Z"))
+                )]
+
+        and:
+        1 * cleanupInfoService.isCompletedState(serviceInstanceUuid) >> false
+
+        and:
+        1 * cleanupAction.executeCleanupServiceInstance(_) >> Mono.error(new RuntimeException("Craaaash"));
+
+        when:
+        sut.triggerCleanup();
+
+        then:
+        noExceptionThrown();
+
+        and:
+        1 * alertingClient.alert({
+            Failure f ->
+                f.message().equals("Cleanup ServiceInstance failed for ${serviceInstanceUuid}".toString()) &&
+                        f.description().equals("Error during cleanup: Craaaash") &&
+                        f.exception() instanceof RuntimeException;
+        })
+
+        and:
+        0 * cleanupInfoService.setCompletedState(serviceInstanceUuid) >> true
+    }
+}

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cleanup/LongRunningAction.java
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cleanup/LongRunningAction.java
@@ -1,0 +1,34 @@
+package com.swisscom.cloud.sb.broker.cleanup;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+class LongRunningAction implements CleanupAction {
+    protected static final Logger LOGGER = LoggerFactory.getLogger(LongRunningAction.class);
+
+    private long sleepInterval = 500;
+    private long sleepIterations = 10;
+
+    private UUID id = UUID.randomUUID();
+
+    @Override
+    public Mono<Boolean> executeCleanupServiceInstance(String serviceInstanceUuid) {
+        LOGGER.info("executeCleanupServiceInstance({})", serviceInstanceUuid);
+
+        return Mono.fromCallable(() -> {
+            for (int i = 0; i <= sleepIterations; i++) {
+                LOGGER.info("{}: {} iterations of {} - {}", serviceInstanceUuid, i, sleepIterations, id);
+                try {
+                    Thread.sleep(sleepInterval);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+
+            return true;
+        });
+    }
+}

--- a/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClientSpec.groovy
+++ b/broker/core/src/test/groovy/com/swisscom/cloud/sb/broker/cleanup/OpsGenieAlertingClientSpec.groovy
@@ -1,0 +1,41 @@
+package com.swisscom.cloud.sb.broker.cleanup
+
+import com.ifountain.opsgenie.client.swagger.model.CreateAlertRequest
+import org.springframework.cloud.servicebroker.exception.ServiceBrokerException
+import spock.lang.Ignore
+import spock.lang.Specification
+
+@Ignore
+class OpsGenieAlertingClientSpec extends Specification {
+
+    OpsGenieAlertingClient sut;
+
+    void setup() {
+        String apiKey = "<redacted>";
+
+        sut = new OpsGenieAlertingClient(
+                new OpsGenieAlertingClientConfiguration(
+                        apiKey: apiKey,
+                        alertPriority: CreateAlertRequest.PriorityEnum.P4,
+                        tags: ["test", "osb"],
+                        alertMessage: "this service specific message",
+                        alertDescription: "<b>Miauz</b><br />well well well.<br />something else"
+                )
+        )
+    }
+
+    void 'alert(): should send failure alert'() {
+        given:
+        Failure failure = Failure.builder()
+                .message("something bad happened")
+                .description("really really bad")
+                .exception(new ServiceBrokerException("baaaad"))
+                .build();
+
+        when:
+        sut.alert(failure);
+
+        then:
+        noExceptionThrown();
+    }
+}


### PR DESCRIPTION
Cleanup services can be used scheduled or manually triggered to have service instances cleaned up.
The cleanup services is designed to only support a single service type and not multiple.