### PR TITLE
refactor: Allow Setting RetryHandler

### DIFF
--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/test/httpserver/HttpServerApp.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/test/httpserver/HttpServerApp.groovy
@@ -19,10 +19,7 @@ import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
-import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration
-import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.cloud.servicebroker.autoconfigure.web.ServiceBrokerAutoConfiguration
 import org.springframework.cloud.servicebroker.autoconfigure.web.servlet.ServiceBrokerWebMvcAutoConfiguration
@@ -31,7 +28,7 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Configuration
 
 @SpringBootApplication(scanBasePackageClasses = HttpServerApp.class,
-        exclude = [ServiceBrokerWebMvcAutoConfiguration.class, ServiceBrokerAutoConfiguration.class])
+        exclude = [ServiceBrokerWebMvcAutoConfiguration.class, ServiceBrokerAutoConfiguration.class, FlywayAutoConfiguration.class])
 @Configuration
 @Slf4j
 @CompileStatic

--- a/broker/src/integration-test/groovy/com/swisscom/cloud/sb/test/httpserver/HttpServerApp.groovy
+++ b/broker/src/integration-test/groovy/com/swisscom/cloud/sb/test/httpserver/HttpServerApp.groovy
@@ -31,7 +31,7 @@ import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Configuration
 
 @SpringBootApplication(scanBasePackageClasses = HttpServerApp.class,
-        exclude = [ServiceBrokerWebMvcAutoConfiguration.class])
+        exclude = [ServiceBrokerWebMvcAutoConfiguration.class, ServiceBrokerAutoConfiguration.class])
 @Configuration
 @Slf4j
 @CompileStatic

--- a/model/src/main/groovy/com/swisscom/cloud/sb/broker/util/RestTemplateBuilder.groovy
+++ b/model/src/main/groovy/com/swisscom/cloud/sb/broker/util/RestTemplateBuilder.groovy
@@ -17,12 +17,14 @@ package com.swisscom.cloud.sb.broker.util
 
 import groovy.transform.CompileStatic
 import groovy.transform.Synchronized
+import org.apache.http.ConnectionReuseStrategy
 import org.apache.http.HttpHost
 import org.apache.http.auth.AuthScope
 import org.apache.http.auth.UsernamePasswordCredentials
 import org.apache.http.client.AuthCache
 import org.apache.http.client.CredentialsProvider
 import org.apache.http.client.HttpClient
+import org.apache.http.client.HttpRequestRetryHandler
 import org.apache.http.client.protocol.ClientContext
 import org.apache.http.conn.ssl.TrustStrategy
 import org.apache.http.conn.ssl.X509HostnameVerifier
@@ -80,8 +82,9 @@ class RestTemplateBuilder {
         if (disableHostNameVerification) {
             httpClientBuilder.setHostnameVerifier(DummyHostnameVerifier.INSTANCE)
         }
-        def httpClientRequestFactory = (useDigestAuth) ? new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactoryDigestAuth(
-                httpClientBuilder.build())) : new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClientBuilder.build()))
+        def httpClientRequestFactory = (useDigestAuth)
+                ? new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactoryDigestAuth(httpClientBuilder.build()))
+                : new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClientBuilder.build()))
         addLoggingRequestInterceptor()
         restTemplate.setRequestFactory(httpClientRequestFactory)
         return this.restTemplate
@@ -128,6 +131,11 @@ class RestTemplateBuilder {
         useDigestAuth = true
         httpClientBuilder.setDefaultCredentialsProvider(provider(user, password)).useSystemProperties()
         this
+    }
+
+    RestTemplateBuilder withRetryHandler(HttpRequestRetryHandler retryHandler) {
+        httpClientBuilder.setRetryHandler(retryHandler)
+        return this
     }
 
     @Synchronized


### PR DESCRIPTION
By allowing to set the httpclient retryhandler
cases like connection issues with PUT requests
can be retried, when the API is idempotent.